### PR TITLE
build: add windows installer/uninstaller

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -69,6 +69,8 @@ var (
 		executablePath("evm"),
 		executablePath("geth"),
 		executablePath("rlpdump"),
+		executablePath("disasm"),
+		executablePath("bootnode"),
 	}
 
 	// A debian package is created for all executables listed here.
@@ -384,7 +386,6 @@ func maybeSkipArchive(env build.Environment) {
 }
 
 // Debian Packaging
-
 func doDebianSource(cmdline []string) {
 	var (
 		signer  = flag.String("signer", "", `Signing key name, also used as package author`)
@@ -563,7 +564,6 @@ func stageDebianSource(tmpdir string, meta debMetadata) (pkgdir string) {
 }
 
 // Windows installer
-
 func doWindowsInstaller(cmdline []string) {
 	// Parse the flags and make skip installer generation on PRs
 	var (
@@ -577,49 +577,63 @@ func doWindowsInstaller(cmdline []string) {
 	env := build.Env()
 	maybeSkipArchive(env)
 
+	defer os.RemoveAll(*workdir)
+
 	// Configure and run the NSIS installer maker. This assumes that all the needed
 	// files have been previously built (don't mix building and packaging to keep
 	// cross compilation complexity to a minimum).
 	var (
-		base    = archiveBasename(*arch, env)
-		version = strings.Split(build.VERSION(), ".")
+		base            = archiveBasename(*arch, env)
+		installerName   = "geth-" + base
+		installFilename = "/DOUTPUTFILE=" + installerName
 
+		version      = strings.Split(build.VERSION(), ".")
 		majorVersion = "/DMAJORVERSION=" + version[0]
 		minorVersion = "/DMINORVERSION=" + version[1]
 		buildId      = "/DBUILDVERSION=" + version[2]
 		buildArch    = "/DARCH=" + *arch
 	)
-	bundles := []struct {
-		name    string
-		content []string
-	}{
-		{"geth-" + base, gethArchiveFiles},
-		{"geth-alltools-" + base, allToolsArchiveFiles},
+
+	// aggregate binaries that are included in the installer
+	var devTools, allTools []string
+	var gethTool string
+	for _, file := range allToolsArchiveFiles {
+		if file == "COPYING" { // license, copied later
+			continue
+		}
+		allTools = append(allTools, filepath.Base(file))
+		if filepath.Base(file) == "geth.exe" {
+			gethTool = file
+		} else {
+			devTools = append(devTools, file)
+		}
 	}
-	for _, bundle := range bundles {
-		// Run NSIS for this specific bundle
-		outputFile := "/DOUTPUTFILE=" + bundle.name
 
-		tools := []string{}
-		for _, file := range bundle.content {
-			name := filepath.Base(file)
-			if name != "geth.exe" && name != "COPYING" {
-				tools = append(tools, name)
-			}
-			build.CopyFile(filepath.Join(*workdir, name), file, 0755)
-		}
-		build.Render("build/nsis.geth.nsi", filepath.Join(*workdir, "geth.nsi"), 0644, nil)
-		build.Render("build/nsis.install.nsh", filepath.Join(*workdir, "install.nsh"), 0644, tools)
-		build.Render("build/nsis.uninstall.nsh", filepath.Join(*workdir, "uninstall.nsh"), 0644, tools)
-		build.Render("build/nsis.envvarupdate.nsh", filepath.Join(*workdir, "EnvVarUpdate.nsh"), 0644, nil)
+	// render NSIS scripts
 
-		build.CopyFile(filepath.Join(*workdir, "SimpleFC.dll"), "build/nsis.simplefc.dll", 0755)
-		makensis := exec.Command("makensis.exe", outputFile, majorVersion, minorVersion, buildId, buildArch, filepath.Join(*workdir, "geth.nsi"))
-		build.MustRun(makensis)
+	// installer NSIS contains two installer sections,
+	// first section contains the geth binary,
+	// second section holds the dev tools.
+	installer := map[string]interface{}{
+		"License":  "COPYING",
+		"Geth":     gethTool,
+		"DevTools": devTools,
+	}
 
-		if err := archiveUpload(filepath.Join(*workdir, bundle.name+".exe"), *upload, *signer); err != nil {
-			log.Fatal(err)
-		}
+	build.Render("build/nsis.geth.nsi", filepath.Join(*workdir, "geth.nsi"), 0644, nil)
+	build.Render("build/nsis.install.nsh", filepath.Join(*workdir, "install.nsh"), 0644, installer)
+	build.Render("build/nsis.uninstall.nsh", filepath.Join(*workdir, "uninstall.nsh"), 0644, allTools)
+	build.Render("build/nsis.envvarupdate.nsh", filepath.Join(*workdir, "EnvVarUpdate.nsh"), 0644, nil)
+
+	build.CopyFile(filepath.Join(*workdir, "SimpleFC.dll"), "build/nsis.simplefc.dll", 0755)
+	build.CopyFile(filepath.Join(*workdir, "COPYING"), "COPYING", 0755)
+
+	makensis := exec.Command("makensis.exe", installFilename, majorVersion, minorVersion, buildId, buildArch, filepath.Join(*workdir, "geth.nsi"))
+	build.MustRun(makensis)
+
+	// Sign and publish installer.
+	if err := archiveUpload(filepath.Join(*workdir, installerName+".exe"), *upload, *signer); err != nil {
+		log.Fatal(err)
 	}
 }
 

--- a/build/nsis.install.nsh
+++ b/build/nsis.install.nsh
@@ -9,13 +9,13 @@ OutFile "${OUTPUTFILE}.exe" # OUTPUTFILE set through command line arguments
 !define /date NOW "%Y%m%d"
 
 PageEx license
-	LicenseData COPYING
+	LicenseData {{.License}}
 PageExEnd
 
 # Install geth binary
 Section "Geth" GETH_IDX
 	SetOutPath $INSTDIR
-	file geth.exe
+	file {{.Geth}}
 
     # Create start menu launcher
     createDirectory "$SMPROGRAMS\${APPNAME}"
@@ -44,7 +44,7 @@ SectionEnd
 # Install optional develop tools.
 Section /o "Development tools" DEV_TOOLS_IDX
 	SetOutPath $INSTDIR
-	{{range $}}file {{$}}
+	{{range $.DevTools}}file {{.}}
 	{{end}}
 SectionEnd
 

--- a/build/nsis.uninstall.nsh
+++ b/build/nsis.uninstall.nsh
@@ -3,9 +3,8 @@ Section "Uninstall"
     setShellVarContext all
 
     # Delete (optionally) installed files
-    {{range $}}Delete $INSTDIR\{{$}}
+    {{range $}}Delete $INSTDIR\{{.}}
     {{end}}
-    Delete $INSTDIR\geth.exe
     Delete $INSTDIR\uninstall.exe
 
     # Delete install directory


### PR DESCRIPTION
Biggest changes:
- single installer that also creates an uninstaller in INSTDIR
- removes temporary work directory after upload
- add bootnode and disasm to `allToolsArchiveFiles`