### PR TITLE
freezer: implement split files for data

### DIFF
--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -74,7 +74,7 @@ func newFreezer(datadir string, namespace string) (*freezer, error) {
 		tables: make(map[string]*freezerTable),
 	}
 	for _, name := range []string{"hashes", "headers", "bodies", "receipts", "diffs"} {
-		table, err := newTable(datadir, name, readMeter, writeMeter)
+		table, err := newDefaultTable(datadir, name, readMeter, writeMeter)
 		if err != nil {
 			for _, table := range freezer.tables {
 				table.Close()

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -74,7 +74,7 @@ func newFreezer(datadir string, namespace string) (*freezer, error) {
 		tables: make(map[string]*freezerTable),
 	}
 	for _, name := range []string{"hashes", "headers", "bodies", "receipts", "diffs"} {
-		table, err := newDefaultTable(datadir, name, readMeter, writeMeter)
+		table, err := newTable(datadir, name, readMeter, writeMeter)
 		if err != nil {
 			for _, table := range freezer.tables {
 				table.Close()

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -40,61 +40,99 @@ var (
 	errOutOfBounds = errors.New("out of bounds")
 )
 
+type index struct {
+	filenum uint16
+	offset  uint64
+}
+
+const indexSize = 12
+
+// unmarshallBinary deserializes binary b into the rawIndex entry.
+func (i *index) unmarshalBinary(b []byte) error {
+	i.filenum = binary.BigEndian.Uint16(b[:4])
+	i.offset = binary.BigEndian.Uint64(b[4:12])
+	return nil
+}
+
+// marshallBinary serializes the rawIndex entry into binary.
+func (i *index) marshallBinary() []byte {
+	b := make([]byte, indexSize)
+	binary.BigEndian.PutUint16(b[:4], i.filenum)
+	binary.BigEndian.PutUint64(b[4:12], i.offset)
+	return b
+}
+
 // freezerTable represents a single chained data table within the freezer (e.g. blocks).
 // It consists of a data file (snappy encoded arbitrary data blobs) and an index
 // file (uncompressed 64 bit indices into the data file).
 type freezerTable struct {
-	content *os.File // File descriptor for the data content of the table
-	offsets *os.File // File descriptor for the index file of the table
+	head    *os.File            // File descriptor for the data head of the table
+	files   map[uint16]*os.File // open files
+	id      uint16              // number of the currently active head file
+	offsets *os.File            // File descriptor for the index file of the table
 
-	items uint64 // Number of items stored in the table
-	bytes uint64 // Number of content bytes stored in the table
+	noCompression bool   // if true, disables snappy compression. Note: does not work retroactively
+	items         uint64 // Number of items stored in the table
+	bytes         uint64 // Number of head bytes stored in the table
+	name          string
+	path          string
+	readMeter     metrics.Meter // Meter for measuring the effective amount of data read
+	writeMeter    metrics.Meter // Meter for measuring the effective amount of data written
 
-	readMeter  metrics.Meter // Meter for measuring the effective amount of data read
-	writeMeter metrics.Meter // Meter for measuring the effective amount of data written
+	logger         log.Logger   // Logger with database path and table name ambedded
+	lock           sync.RWMutex // Mutex protecting the data file descriptors
+	maxContentSize uint64       // Max file size for data-files
 
-	logger log.Logger   // Logger with database path and table name ambedded
-	lock   sync.RWMutex // Mutex protecting the data file descriptors
+}
+
+func newDefaultTable(path string, name string, readMeter metrics.Meter, writeMeter metrics.Meter) (*freezerTable, error) {
+	return newTable(path, name, readMeter, writeMeter, 2*1000*1000*1000, false)
 }
 
 // newTable opens a freezer table, creating the data and index files if they are
 // non existent. Both files are truncated to the shortest common length to ensure
 // they don't go out of sync.
-func newTable(path string, name string, readMeter metrics.Meter, writeMeter metrics.Meter) (*freezerTable, error) {
-	// Ensure the containing directory exists and open the two data files
+func newTable(path string, name string, readMeter metrics.Meter, writeMeter metrics.Meter, maxFilesize uint64, noCompression bool) (*freezerTable, error) {
+	// Ensure the containing directory exists and open the index file
 	if err := os.MkdirAll(path, 0755); err != nil {
 		return nil, err
 	}
-	content, err := os.OpenFile(filepath.Join(path, name+".dat"), os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
-	if err != nil {
-		return nil, err
+	var idxName string
+	if noCompression {
+		// raw idx
+		idxName = fmt.Sprintf("%s.ridx", name)
+	} else {
+		// compressed idx
+		idxName = fmt.Sprintf("%s.cidx", name)
 	}
-	offsets, err := os.OpenFile(filepath.Join(path, name+".idx"), os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
+	offsets, err := os.OpenFile(filepath.Join(path, idxName), os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
 	if err != nil {
-		content.Close()
 		return nil, err
 	}
 	// Create the table and repair any past inconsistency
 	tab := &freezerTable{
-		content:    content,
-		offsets:    offsets,
-		readMeter:  readMeter,
-		writeMeter: writeMeter,
-		logger:     log.New("database", path, "table", name),
+		offsets:        offsets,
+		files:          make(map[uint16]*os.File),
+		readMeter:      readMeter,
+		writeMeter:     writeMeter,
+		name:           name,
+		path:           path,
+		logger:         log.New("database", path, "table", name),
+		noCompression:  noCompression,
+		maxContentSize: maxFilesize,
 	}
 	if err := tab.repair(); err != nil {
-		offsets.Close()
-		content.Close()
+		tab.Close()
 		return nil, err
 	}
 	return tab, nil
 }
 
-// repair cross checks the content and the offsets file and truncates them to
+// repair cross checks the head and the offsets file and truncates them to
 // be in sync with each other after a potential crash / data loss.
 func (t *freezerTable) repair() error {
-	// Create a temporary offset buffer to init files with and read offsts into
-	offset := make([]byte, 8)
+	// Create a temporary offset buffer to init files with and read offsets into
+	offset := make([]byte, indexSize)
 
 	// If we've just created the files, initialize the offsets with the 0 index
 	stat, err := t.offsets.Stat()
@@ -106,8 +144,8 @@ func (t *freezerTable) repair() error {
 			return err
 		}
 	}
-	// Ensure the offsets are a multiple of 8 bytes
-	if overflow := stat.Size() % 8; overflow != 0 {
+	// Ensure the offsets are a multiple of indexSize bytes
+	if overflow := stat.Size() % indexSize; overflow != 0 {
 		t.offsets.Truncate(stat.Size() - overflow) // New file can't trigger this path
 	}
 	// Retrieve the file sizes and prepare for truncation
@@ -115,46 +153,67 @@ func (t *freezerTable) repair() error {
 		return err
 	}
 	offsetsSize := stat.Size()
-
-	if stat, err = t.content.Stat(); err != nil {
+	// Open the head file
+	var (
+		lastIndex   index
+		contentSize uint64
+		contentExp  uint64
+	)
+	t.offsets.ReadAt(offset, offsetsSize-indexSize)
+	lastIndex.unmarshalBinary(offset)
+	t.head, err = t.getFile(lastIndex.filenum, os.O_RDWR|os.O_CREATE|os.O_APPEND)
+	if err != nil {
 		return err
 	}
-	contentSize := stat.Size()
-
+	if stat, err = t.head.Stat(); err != nil {
+		return err
+	}
+	contentSize = uint64(stat.Size())
 	// Keep truncating both files until they come in sync
-	t.offsets.ReadAt(offset, offsetsSize-8)
-	contentExp := int64(binary.LittleEndian.Uint64(offset))
+	contentExp = lastIndex.offset
 
 	for contentExp != contentSize {
-		// Truncate the content file to the last offset pointer
+		// Truncate the head file to the last offset pointer
 		if contentExp < contentSize {
-			t.logger.Warn("Truncating dangling content", "indexed", common.StorageSize(contentExp), "stored", common.StorageSize(contentSize))
-			if err := t.content.Truncate(contentExp); err != nil {
+			t.logger.Warn("Truncating dangling head", "indexed", common.StorageSize(contentExp), "stored", common.StorageSize(contentSize))
+			if err := t.head.Truncate(int64(contentExp)); err != nil {
 				return err
 			}
 			contentSize = contentExp
 		}
-		// Truncate the offsets to point within the content file
+		// Truncate the offsets to point within the head file
 		if contentExp > contentSize {
 			t.logger.Warn("Truncating dangling offsets", "indexed", common.StorageSize(contentExp), "stored", common.StorageSize(contentSize))
-			if err := t.offsets.Truncate(offsetsSize - 8); err != nil {
+			if err := t.offsets.Truncate(offsetsSize - indexSize); err != nil {
 				return err
 			}
-			offsetsSize -= 8
-
-			t.offsets.ReadAt(offset, offsetsSize-8)
-			contentExp = int64(binary.LittleEndian.Uint64(offset))
+			offsetsSize -= indexSize
+			t.offsets.ReadAt(offset, offsetsSize-indexSize)
+			var newLastIndex index
+			newLastIndex.unmarshalBinary(offset)
+			// We might have slipped back into an earlier head-file here
+			if newLastIndex.filenum != lastIndex.filenum {
+				t.head, err = t.getFile(newLastIndex.filenum, os.O_RDWR|os.O_CREATE|os.O_APPEND)
+				if stat, err = t.head.Stat(); err != nil {
+					// TODO, anything more we can do here?
+					// A data file has gone missing...
+					return err
+				}
+				contentSize = uint64(stat.Size())
+			}
+			lastIndex = newLastIndex
+			contentExp = lastIndex.offset
 		}
 	}
 	// Ensure all reparation changes have been written to disk
 	if err := t.offsets.Sync(); err != nil {
 		return err
 	}
-	if err := t.content.Sync(); err != nil {
+	if err := t.head.Sync(); err != nil {
 		return err
 	}
 	// Update the item and byte counters and return
-	t.items = uint64(offsetsSize/8 - 1) // last index points to the end of the data file
+	t.items = uint64(offsetsSize/indexSize - 1) // last index points to the end of the data file
 	t.bytes = uint64(contentSize)
 
 	t.logger.Debug("Chain freezer table opened", "items", t.items, "size", common.StorageSize(t.bytes))
@@ -177,7 +236,7 @@ func (t *freezerTable) truncate(items uint64) error {
 	t.offsets.ReadAt(offset, int64(items)*8)
 	expected := binary.LittleEndian.Uint64(offset)
 
-	if err := t.content.Truncate(int64(expected)); err != nil {
+	if err := t.head.Truncate(int64(expected)); err != nil {
 		return err
 	}
 	// All data files truncated, set internal counters and return
@@ -185,7 +244,7 @@ func (t *freezerTable) truncate(items uint64) error {
 	return nil
 }
 
-// Close unmaps all active memory mapped regions.
+// Close closes all opened files.
 func (t *freezerTable) Close() error {
 	t.lock.Lock()
 	defer t.lock.Unlock()
@@ -196,15 +255,38 @@ func (t *freezerTable) Close() error {
 	}
 	t.offsets = nil
 
-	if err := t.content.Close(); err != nil {
-		errs = append(errs, err)
+	for _, f := range t.files {
+		if err := f.Close(); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	t.content = nil
+
+	t.head = nil
 
 	if errs != nil {
 		return fmt.Errorf("%v", errs)
 	}
 	return nil
+}
+
+// getFile either returns an existing handle, or opens the file with the
+// given flags (and stores the handle for later)
+func (t *freezerTable) getFile(num uint16, flag int) (f *os.File, err error) {
+	var exist bool
+	if f, exist = t.files[num]; !exist {
+		var fname string
+		if t.noCompression {
+			fname = fmt.Sprintf("%s.%d.rdat", t.name, num)
+		} else {
+			fname = fmt.Sprintf("%s.%d.cdat", t.name, num)
+		}
+		f, err = os.OpenFile(filepath.Join(t.path, fname), flag, 0644)
+		if err != nil {
+			return nil, err
+		}
+		t.files[num] = f
+	}
+	return f, nil
 }
 
 // Append injects a binary blob at the end of the freezer table. The item index
@@ -215,7 +297,7 @@ func (t *freezerTable) Close() error {
 // fsync before irreversibly deleting data from the database.
 func (t *freezerTable) Append(item uint64, blob []byte) error {
 	// Ensure the table is still accessible
-	if t.offsets == nil || t.content == nil {
+	if t.offsets == nil || t.head == nil {
 		return errClosed
 	}
 	// Ensure only the next item can be written, nothing else
@@ -223,21 +305,62 @@ func (t *freezerTable) Append(item uint64, blob []byte) error {
 		panic(fmt.Sprintf("appending unexpected item: want %d, have %d", t.items, item))
 	}
 	// Encode the blob and write it into the data file
-	blob = snappy.Encode(nil, blob)
-	if _, err := t.content.Write(blob); err != nil {
-		return err
+	if !t.noCompression {
+		blob = snappy.Encode(nil, blob)
 	}
-	t.bytes += uint64(len(blob))
+	bLen := uint64(len(blob))
+	if t.bytes+bLen > t.maxContentSize {
 
-	offset := make([]byte, 8)
-	binary.LittleEndian.PutUint64(offset, t.bytes)
-	if _, err := t.offsets.Write(offset); err != nil {
-		return err
+		// we need a new file, writing would overflow
+		nextId := t.id + 1
+		// We open the next file in truncated mode -- if this file already
+		// exists, we need to start over from scratch on it
+		content, err := t.getFile(nextId, os.O_RDWR|os.O_CREATE|os.O_TRUNC)
+		if err != nil {
+			return err
+		}
+		// Swap out the current file
+		t.head = content
+		t.bytes = 0
+		t.id = nextId
 	}
+	t.head.Write(blob)
+	t.bytes += bLen
+	idx := index{
+		filenum: t.id,
+		offset:  t.bytes,
+	}
+	// Write offsets
+	t.offsets.Write(idx.marshallBinary())
+	t.writeMeter.Mark(int64(bLen + 12)) // 12 = 1 x 12 byte index
 	t.items++
-
-	t.writeMeter.Mark(int64(len(blob) + 8)) // 8 = 1 x 8 byte offset
 	return nil
+}
+
+// getOffsets returns the indexes for the item
+func (t *freezerTable) getOffsets(item uint64) (*index, *index, error) {
+
+	var start, end index
+	indexdata := make([]byte, 12)
+	if _, err := t.offsets.ReadAt(indexdata, int64(item*12)); err != nil {
+		return nil, nil, err
+	}
+	start.unmarshalBinary(indexdata)
+	if _, err := t.offsets.ReadAt(indexdata, int64((item+1)*12)); err != nil {
+		return nil, nil, err
+	}
+	end.unmarshalBinary(indexdata)
+
+	if start.filenum != end.filenum {
+		// If a piece of data 'crosses' a data-file,
+		// it's actually in one piece on the second data-file.
+		// We return a zero-index for the second file as start
+		start = index{
+			filenum: end.filenum,
+			offset:  0,
+		}
+	}
+	return &start, &end, nil
 }
 
 // Retrieve looks up the data offset of an item with the given index and retrieves
@@ -247,31 +370,32 @@ func (t *freezerTable) Retrieve(item uint64) ([]byte, error) {
 	defer t.lock.RUnlock()
 
 	// Ensure the table and the item is accessible
-	if t.offsets == nil || t.content == nil {
+	if t.offsets == nil || t.head == nil {
 		return nil, errClosed
 	}
 	if t.items <= item {
 		return nil, errOutOfBounds
 	}
-	// Item reachable, retrieve the data content boundaries
-	offset := make([]byte, 8)
-	if _, err := t.offsets.ReadAt(offset, int64(item*8)); err != nil {
+	start, end, err := t.getOffsets(item)
+	if err != nil {
 		return nil, err
 	}
-	start := binary.LittleEndian.Uint64(offset)
-
-	if _, err := t.offsets.ReadAt(offset, int64((item+1)*8)); err != nil {
+	dataFile, err := t.getFile(start.filenum, os.O_RDONLY)
+	if err != nil {
 		return nil, err
 	}
-	end := binary.LittleEndian.Uint64(offset)
-
 	// Retrieve the data itself, decompress and return
-	blob := make([]byte, end-start)
-	if _, err := t.content.ReadAt(blob, int64(start)); err != nil {
+	blob := make([]byte, end.offset-start.offset)
+	if _, err := dataFile.ReadAt(blob, int64(start.offset)); err != nil {
 		return nil, err
 	}
-	t.readMeter.Mark(int64(len(blob) + 16)) // 16 = 2 x 8 byte offset
-	return snappy.Decode(nil, blob)
+	t.readMeter.Mark(int64(len(blob) + 2*indexSize)) // 16 = 2 x 8 byte offset
+
+	if !t.noCompression {
+		return snappy.Decode(nil, blob)
+	} else {
+		return blob, nil
+	}
 }
 
 // Sync pushes any pending data from memory out to disk. This is an expensive
@@ -280,5 +404,5 @@ func (t *freezerTable) Sync() error {
 	if err := t.offsets.Sync(); err != nil {
 		return err
 	}
-	return t.content.Sync()
+	return t.head.Sync()
 }

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -40,6 +40,8 @@ var (
 	errOutOfBounds = errors.New("out of bounds")
 )
 
+// indexEntry contains the number/id of the file that the data resides in, aswell as the
+// offset within the file to the end of the data
 type indexEntry struct {
 	filenum uint16
 	offset  uint64

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -114,7 +114,7 @@ func TestFreezerBasicsClosing(t *testing.T) {
 	}
 }
 
-// TestFreezerRepairDanglingHead tests that we can recover if offsets are removed
+// TestFreezerRepairDanglingHead tests that we can recover if index are removed
 func TestFreezerRepairDanglingHead(t *testing.T) {
 	t.Parallel()
 	wm, rm := metrics.NewMeter(), metrics.NewMeter()
@@ -162,7 +162,7 @@ func TestFreezerRepairDanglingHead(t *testing.T) {
 	}
 }
 
-// TestFreezerRepairDanglingHeadLarge tests that we can recover if very many offsets are removed
+// TestFreezerRepairDanglingHeadLarge tests that we can recover if very many index are removed
 func TestFreezerRepairDanglingHeadLarge(t *testing.T) {
 	t.Parallel()
 	wm, rm := metrics.NewMeter(), metrics.NewMeter()
@@ -371,8 +371,8 @@ func TestFreezerTruncate(t *testing.T) {
 			t.Fatalf("expected %d items, got %d", 10, f.items)
 		}
 		// 45, 45, 45, 15 -- bytes should be 15
-		if f.bytes != 15 {
-			t.Fatalf("expected %d bytes, got %d", 15, f.bytes)
+		if f.headBytes != 15 {
+			t.Fatalf("expected %d bytes, got %d", 15, f.headBytes)
 		}
 
 	}


### PR DESCRIPTION
This PR does a couple of things:

- Implements data storage across several files. The max file size is customizable per table,
- Makes snappy encoding optional (per table). Filename suffix reveals if the file(s) are snappy-encoded or not. 
- Adds testcases for all new functionality, 

The format change is now that the index are tuples, `filenum[uint16], offset[uint64]`. 
Example, if blocks are `100` bytes and maxfilesize is `350` bytes
```
// Empty
data:   []
index: [0:0]

// One block
data:  [block0]
index: [0:0,0:100]

// Four blocks, spills over into a secondary file
data:  [block0, block1, block2][block3]
index: [0:0, 0:100, 0:200, 0:300, 1:100]
```
The data-files will never go above the threshold, _unless_ a piece of data to store is actually larger than the threshold (would typically only happen in tests, or if someone imports this db and uses it with very odd settings)

This PR does not implement any fancy open files cache, just keeps a map of open files. Only the `head`-file is in read/write, the others in `read-only`. We might want to add some lru on the open files, but if we use `2G` files, it shouldn't be much of a problem (?)

Todo

- [x] When opening a new (next) file, we should close previous `head` file (and possibly reopen in `rdonly` mode). Only the `head` should be `rdwr`.
- [x] Fix `truncate`, and add tests