### PR TITLE
Freezer offset

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -367,8 +367,11 @@ func exportPreimages(ctx *cli.Context) error {
 
 func copyDb(ctx *cli.Context) error {
 	// Ensure we have a source chain directory to copy
-	if len(ctx.Args()) != 1 {
+	if len(ctx.Args()) < 1 {
 		utils.Fatalf("Source chaindata directory path argument missing")
+	}
+	if len(ctx.Args()) < 2 {
+		utils.Fatalf("Source ancient chain directory path argument missing")
 	}
 	// Initialize a new chain for the running node to sync into
 	stack := makeFullNode(ctx)
@@ -379,7 +382,7 @@ func copyDb(ctx *cli.Context) error {
 	dl := downloader.New(syncmode, 0, chainDb, new(event.TypeMux), chain, nil, nil)
 
 	// Create a source peer to satisfy downloader requests from
-	db, err := rawdb.NewLevelDBDatabase(ctx.Args().First(), ctx.GlobalInt(utils.CacheFlag.Name), 256, "")
+	db, err := rawdb.NewLevelDBDatabaseWithFreezer(ctx.Args().First(), ctx.GlobalInt(utils.CacheFlag.Name), 256, ctx.Args().Get(1), "")
 	if err != nil {
 		return err
 	}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -61,6 +61,7 @@ var (
 		utils.BootnodesV4Flag,
 		utils.BootnodesV5Flag,
 		utils.DataDirFlag,
+		utils.AncientFlag,
 		utils.KeyStoreDirFlag,
 		utils.ExternalSignerFlag,
 		utils.NoUSBFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -69,6 +69,7 @@ var AppHelpFlagGroups = []flagGroup{
 		Flags: []cli.Flag{
 			configFileFlag,
 			utils.DataDirFlag,
+			utils.AncientFlag,
 			utils.KeyStoreDirFlag,
 			utils.NoUSBFlag,
 			utils.NetworkIdFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -120,6 +120,10 @@ var (
 		Usage: "Data directory for the databases and keystore",
 		Value: DirectoryString{node.DefaultDataDir()},
 	}
+	AncientFlag = DirectoryFlag{
+		Name:  "datadir.ancient",
+		Usage: "Data directory for ancient chain segments (default = inside chaindata)",
+	}
 	KeyStoreDirFlag = DirectoryFlag{
 		Name:  "keystore",
 		Usage: "Directory for the keystore (default = inside the datadir)",
@@ -1381,6 +1385,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 		cfg.DatabaseCache = ctx.GlobalInt(CacheFlag.Name) * ctx.GlobalInt(CacheDatabaseFlag.Name) / 100
 	}
 	cfg.DatabaseHandles = makeDatabaseHandles()
+	if ctx.GlobalIsSet(AncientFlag.Name) {
+		cfg.DatabaseFreezer = ctx.GlobalString(AncientFlag.Name)
+	}
 
 	if gcmode := ctx.GlobalString(GCModeFlag.Name); gcmode != "full" && gcmode != "archive" {
 		Fatalf("--%s must be either 'full' or 'archive'", GCModeFlag.Name)
@@ -1569,7 +1576,7 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node) ethdb.Database {
 	if ctx.GlobalString(SyncModeFlag.Name) == "light" {
 		name = "lightchaindata"
 	}
-	chainDb, err := stack.OpenDatabase(name, cache, handles, "")
+	chainDb, err := stack.OpenDatabaseWithFreezer(name, cache, handles, "", "")
 	if err != nil {
 		Fatalf("Could not open database: %v", err)
 	}

--- a/core/rawdb/accessors_indexes.go
+++ b/core/rawdb/accessors_indexes.go
@@ -61,7 +61,7 @@ func DeleteTxLookupEntry(db ethdb.Writer, hash common.Hash) {
 
 // ReadTransaction retrieves a specific transaction from the database, along with
 // its added positional metadata.
-func ReadTransaction(db ethdb.Reader, hash common.Hash) (*types.Transaction, common.Hash, uint64, uint64) {
+func ReadTransaction(db ethdb.AncientReader, hash common.Hash) (*types.Transaction, common.Hash, uint64, uint64) {
 	blockHash := ReadTxLookupEntry(db, hash)
 	if blockHash == (common.Hash{}) {
 		return nil, common.Hash{}, 0, 0
@@ -86,7 +86,7 @@ func ReadTransaction(db ethdb.Reader, hash common.Hash) (*types.Transaction, com
 
 // ReadReceipt retrieves a specific transaction receipt from the database, along with
 // its added positional metadata.
-func ReadReceipt(db ethdb.Reader, hash common.Hash, config *params.ChainConfig) (*types.Receipt, common.Hash, uint64, uint64) {
+func ReadReceipt(db ethdb.AncientReader, hash common.Hash, config *params.ChainConfig) (*types.Receipt, common.Hash, uint64, uint64) {
 	// Retrieve the context of the receipt based on the transaction hash
 	blockHash := ReadTxLookupEntry(db, hash)
 	if blockHash == (common.Hash{}) {

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -1,0 +1,276 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rawdb
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
+)
+
+// errUnknownTable is returned if the user attempts to read from a table that is
+// not tracked by the freezer.
+var errUnknownTable = errors.New("unknown table")
+
+const (
+	// freezerRecheckInterval is the frequency to check the key-value database for
+	// chain progression that might permit new blocks to be frozen into immutable
+	// storage.
+	freezerRecheckInterval = time.Minute
+
+	// freezerBlockGraduation is the number of confirmations a block must achieve
+	// before it becomes elligible for chain freezing. This must exceed any chain
+	// reorg depth, since the freezer also deletes all block siblings.
+	freezerBlockGraduation = 60000
+
+	// freezerBatchLimit is the maximum number of blocks to freeze in one batch
+	// before doing an fsync and deleting it from the key-value store.
+	freezerBatchLimit = 30000
+)
+
+// freezer is an memory mapped append-only database to store immutable chain data
+// into flat files:
+//
+// - The append only nature ensures that disk writes are minimized.
+// - The memory mapping ensures we can max out system memory for caching without
+//   reserving it for go-ethereum. This would also reduce the memory requirements
+//   of Geth, and thus also GC overhead.
+type freezer struct {
+	tables map[string]*freezerTable // Data tables for storing everything
+	frozen uint64                   // Number of blocks already frozen
+}
+
+// newFreezer creates a chain freezer that moves ancient chain data into
+// append-only flat file containers.
+func newFreezer(datadir string, namespace string) (*freezer, error) {
+	// Create the initial freezer object
+	var (
+		readMeter  = metrics.NewRegisteredMeter(namespace+"ancient/read", nil)
+		writeMeter = metrics.NewRegisteredMeter(namespace+"ancient/write", nil)
+	)
+	// Open all the supported data tables
+	freezer := &freezer{
+		tables: make(map[string]*freezerTable),
+	}
+	for _, name := range []string{"hashes", "headers", "bodies", "receipts", "diffs"} {
+		table, err := newTable(datadir, name, readMeter, writeMeter)
+		if err != nil {
+			for _, table := range freezer.tables {
+				table.Close()
+			}
+			return nil, err
+		}
+		freezer.tables[name] = table
+	}
+	// Truncate all data tables to the same length
+	freezer.frozen = math.MaxUint64
+	for _, table := range freezer.tables {
+		if freezer.frozen > table.items {
+			freezer.frozen = table.items
+		}
+	}
+	for _, table := range freezer.tables {
+		if err := table.truncate(freezer.frozen); err != nil {
+			for _, table := range freezer.tables {
+				table.Close()
+			}
+			return nil, err
+		}
+	}
+	return freezer, nil
+}
+
+// Close terminates the chain freezer, unmapping all the data files.
+func (f *freezer) Close() error {
+	var errs []error
+	for _, table := range f.tables {
+		if err := table.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if errs != nil {
+		return fmt.Errorf("%v", errs)
+	}
+	return nil
+}
+
+// sync flushes all data tables to disk.
+func (f *freezer) sync() error {
+	var errs []error
+	for _, table := range f.tables {
+		if err := table.Sync(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if errs != nil {
+		return fmt.Errorf("%v", errs)
+	}
+	return nil
+}
+
+// Ancient retrieves an ancient binary blob from the append-only immutable files.
+func (f *freezer) Ancient(kind string, number uint64) ([]byte, error) {
+	if table := f.tables[kind]; table != nil {
+		return table.Retrieve(number)
+	}
+	return nil, errUnknownTable
+}
+
+// freeze is a background thread that periodically checks the blockchain for any
+// import progress and moves ancient data from the fast database into the freezer.
+//
+// This functionality is deliberately broken off from block importing to avoid
+// incurring additional data shuffling delays on block propagation.
+func (f *freezer) freeze(db ethdb.KeyValueStore) {
+	nfdb := &nofreezedb{KeyValueStore: db}
+
+	for {
+		// Retrieve the freezing threshold. In theory we're interested only in full
+		// blocks post-sync, but that would keep the live database enormous during
+		// dast sync. By picking the fast block, we still get to deep freeze all the
+		// final immutable data without having to wait for sync to finish.
+		hash := ReadHeadFastBlockHash(nfdb)
+		if hash == (common.Hash{}) {
+			log.Debug("Current fast block hash unavailable") // new chain, empty database
+			time.Sleep(freezerRecheckInterval)
+			continue
+		}
+		number := ReadHeaderNumber(nfdb, hash)
+		switch {
+		case number == nil:
+			log.Error("Current fast block number unavailable", "hash", hash)
+			time.Sleep(freezerRecheckInterval)
+			continue
+
+		case *number < freezerBlockGraduation:
+			log.Debug("Current fast block not old enough", "number", *number, "hash", hash, "delay", freezerBlockGraduation)
+			time.Sleep(freezerRecheckInterval)
+			continue
+
+		case *number-freezerBlockGraduation <= f.frozen:
+			log.Debug("Ancient blocks frozen already", "number", *number, "hash", hash, "frozen", f.frozen)
+			time.Sleep(freezerRecheckInterval)
+			continue
+		}
+		head := ReadHeader(nfdb, hash, *number)
+		if head == nil {
+			log.Error("Current fast block unavailable", "number", *number, "hash", hash)
+			time.Sleep(freezerRecheckInterval)
+			continue
+		}
+		// Seems we have data ready to be frozen, process in usable batches
+		limit := *number - freezerBlockGraduation
+		if limit-f.frozen > freezerBatchLimit {
+			limit = f.frozen + freezerBatchLimit
+		}
+		var (
+			start    = time.Now()
+			first    = f.frozen
+			ancients = make([]common.Hash, 0, limit)
+		)
+		for f.frozen < limit {
+			// Retrieves all the components of the canonical block
+			hash := ReadCanonicalHash(nfdb, f.frozen)
+			if hash == (common.Hash{}) {
+				log.Error("Canonical hash missing, can't freeze", "number", f.frozen)
+				break
+			}
+			header := ReadHeaderRLP(nfdb, hash, f.frozen)
+			if len(header) == 0 {
+				log.Error("Block header missing, can't freeze", "number", f.frozen, "hash", hash)
+				break
+			}
+			body := ReadBodyRLP(nfdb, hash, f.frozen)
+			if len(body) == 0 {
+				log.Error("Block body missing, can't freeze", "number", f.frozen, "hash", hash)
+				break
+			}
+			receipts := ReadReceiptsRLP(nfdb, hash, f.frozen)
+			if len(receipts) == 0 {
+				log.Error("Block receipts missing, can't freeze", "number", f.frozen, "hash", hash)
+				break
+			}
+			td := ReadTdRLP(nfdb, hash, f.frozen)
+			if len(td) == 0 {
+				log.Error("Total difficulty missing, can't freeze", "number", f.frozen, "hash", hash)
+				break
+			}
+			// Inject all the components into the relevant data tables
+			if err := f.tables["hashes"].Append(f.frozen, hash[:]); err != nil {
+				log.Error("Failed to deep freeze hash", "number", f.frozen, "hash", hash, "err", err)
+				break
+			}
+			if err := f.tables["headers"].Append(f.frozen, header); err != nil {
+				log.Error("Failed to deep freeze header", "number", f.frozen, "hash", hash, "err", err)
+				break
+			}
+			if err := f.tables["bodies"].Append(f.frozen, body); err != nil {
+				log.Error("Failed to deep freeze body", "number", f.frozen, "hash", hash, "err", err)
+				break
+			}
+			if err := f.tables["receipts"].Append(f.frozen, receipts); err != nil {
+				log.Error("Failed to deep freeze receipts", "number", f.frozen, "hash", hash, "err", err)
+				break
+			}
+			if err := f.tables["diffs"].Append(f.frozen, td); err != nil {
+				log.Error("Failed to deep freeze difficulty", "number", f.frozen, "hash", hash, "err", err)
+				break
+			}
+			log.Trace("Deep froze ancient block", "number", f.frozen, "hash", hash)
+			atomic.AddUint64(&f.frozen, 1) // Only modify atomically
+			ancients = append(ancients, hash)
+		}
+		// Batch of blocks have been frozen, flush them before wiping from leveldb
+		if err := f.sync(); err != nil {
+			log.Crit("Failed to flush frozen tables", "err", err)
+		}
+		// Wipe out all data from the active database
+		batch := db.NewBatch()
+		for number := first; number < f.frozen; number++ {
+			for _, hash := range readAllHashes(db, number) {
+				if hash == ancients[number-first] {
+					deleteBlockWithoutNumber(batch, hash, number)
+				} else {
+					DeleteBlock(batch, hash, number)
+				}
+			}
+		}
+		if err := batch.Write(); err != nil {
+			log.Crit("Failed to delete frozen items", "err", err)
+		}
+		// Log something friendly for the user
+		context := []interface{}{
+			"blocks", f.frozen - first, "elapsed", common.PrettyDuration(time.Since(start)), "number", f.frozen - 1,
+		}
+		if n := len(ancients); n > 0 {
+			context = append(context, []interface{}{"hash", ancients[n-1]}...)
+		}
+		log.Info("Deep froze chain segment", context...)
+
+		// Avoid database thrashing with tiny writes
+		if f.frozen-first < freezerBatchLimit {
+			time.Sleep(freezerRecheckInterval)
+		}
+	}
+}

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -1,0 +1,284 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rawdb
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/golang/snappy"
+)
+
+var (
+	// errClosed is returned if an operation attempts to read from or write to the
+	// freezer table after it has already been closed.
+	errClosed = errors.New("closed")
+
+	// errOutOfBounds is returned if the item requested is not contained within the
+	// freezer table.
+	errOutOfBounds = errors.New("out of bounds")
+)
+
+// freezerTable represents a single chained data table within the freezer (e.g. blocks).
+// It consists of a data file (snappy encoded arbitrary data blobs) and an index
+// file (uncompressed 64 bit indices into the data file).
+type freezerTable struct {
+	content *os.File // File descriptor for the data content of the table
+	offsets *os.File // File descriptor for the index file of the table
+
+	items uint64 // Number of items stored in the table
+	bytes uint64 // Number of content bytes stored in the table
+
+	readMeter  metrics.Meter // Meter for measuring the effective amount of data read
+	writeMeter metrics.Meter // Meter for measuring the effective amount of data written
+
+	logger log.Logger   // Logger with database path and table name ambedded
+	lock   sync.RWMutex // Mutex protecting the data file descriptors
+}
+
+// newTable opens a freezer table, creating the data and index files if they are
+// non existent. Both files are truncated to the shortest common length to ensure
+// they don't go out of sync.
+func newTable(path string, name string, readMeter metrics.Meter, writeMeter metrics.Meter) (*freezerTable, error) {
+	// Ensure the containing directory exists and open the two data files
+	if err := os.MkdirAll(path, 0755); err != nil {
+		return nil, err
+	}
+	content, err := os.OpenFile(filepath.Join(path, name+".dat"), os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
+		return nil, err
+	}
+	offsets, err := os.OpenFile(filepath.Join(path, name+".idx"), os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
+		content.Close()
+		return nil, err
+	}
+	// Create the table and repair any past inconsistency
+	tab := &freezerTable{
+		content:    content,
+		offsets:    offsets,
+		readMeter:  readMeter,
+		writeMeter: writeMeter,
+		logger:     log.New("database", path, "table", name),
+	}
+	if err := tab.repair(); err != nil {
+		offsets.Close()
+		content.Close()
+		return nil, err
+	}
+	return tab, nil
+}
+
+// repair cross checks the content and the offsets file and truncates them to
+// be in sync with each other after a potential crash / data loss.
+func (t *freezerTable) repair() error {
+	// Create a temporary offset buffer to init files with and read offsts into
+	offset := make([]byte, 8)
+
+	// If we've just created the files, initialize the offsets with the 0 index
+	stat, err := t.offsets.Stat()
+	if err != nil {
+		return err
+	}
+	if stat.Size() == 0 {
+		if _, err := t.offsets.Write(offset); err != nil {
+			return err
+		}
+	}
+	// Ensure the offsets are a multiple of 8 bytes
+	if overflow := stat.Size() % 8; overflow != 0 {
+		t.offsets.Truncate(stat.Size() - overflow) // New file can't trigger this path
+	}
+	// Retrieve the file sizes and prepare for truncation
+	if stat, err = t.offsets.Stat(); err != nil {
+		return err
+	}
+	offsetsSize := stat.Size()
+
+	if stat, err = t.content.Stat(); err != nil {
+		return err
+	}
+	contentSize := stat.Size()
+
+	// Keep truncating both files until they come in sync
+	t.offsets.ReadAt(offset, offsetsSize-8)
+	contentExp := int64(binary.LittleEndian.Uint64(offset))
+
+	for contentExp != contentSize {
+		// Truncate the content file to the last offset pointer
+		if contentExp < contentSize {
+			t.logger.Warn("Truncating dangling content", "indexed", common.StorageSize(contentExp), "stored", common.StorageSize(contentSize))
+			if err := t.content.Truncate(contentExp); err != nil {
+				return err
+			}
+			contentSize = contentExp
+		}
+		// Truncate the offsets to point within the content file
+		if contentExp > contentSize {
+			t.logger.Warn("Truncating dangling offsets", "indexed", common.StorageSize(contentExp), "stored", common.StorageSize(contentSize))
+			if err := t.offsets.Truncate(offsetsSize - 8); err != nil {
+				return err
+			}
+			offsetsSize -= 8
+
+			t.offsets.ReadAt(offset, offsetsSize-8)
+			contentExp = int64(binary.LittleEndian.Uint64(offset))
+		}
+	}
+	// Ensure all reparation changes have been written to disk
+	if err := t.offsets.Sync(); err != nil {
+		return err
+	}
+	if err := t.content.Sync(); err != nil {
+		return err
+	}
+	// Update the item and byte counters and return
+	t.items = uint64(offsetsSize/8 - 1) // last index points to the end of the data file
+	t.bytes = uint64(contentSize)
+
+	t.logger.Debug("Chain freezer table opened", "items", t.items, "size", common.StorageSize(t.bytes))
+	return nil
+}
+
+// truncate discards any recent data above the provided threashold number.
+func (t *freezerTable) truncate(items uint64) error {
+	// If out item count is corrent, don't do anything
+	if t.items <= items {
+		return nil
+	}
+	// Something's out of sync, truncate the table's offset index
+	t.logger.Warn("Truncating freezer table", "items", t.items, "limit", items)
+	if err := t.offsets.Truncate(int64(items+1) * 8); err != nil {
+		return err
+	}
+	// Calculate the new expected size of the data file and truncate it
+	offset := make([]byte, 8)
+	t.offsets.ReadAt(offset, int64(items)*8)
+	expected := binary.LittleEndian.Uint64(offset)
+
+	if err := t.content.Truncate(int64(expected)); err != nil {
+		return err
+	}
+	// All data files truncated, set internal counters and return
+	t.items, t.bytes = items, expected
+	return nil
+}
+
+// Close unmaps all active memory mapped regions.
+func (t *freezerTable) Close() error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	var errs []error
+	if err := t.offsets.Close(); err != nil {
+		errs = append(errs, err)
+	}
+	t.offsets = nil
+
+	if err := t.content.Close(); err != nil {
+		errs = append(errs, err)
+	}
+	t.content = nil
+
+	if errs != nil {
+		return fmt.Errorf("%v", errs)
+	}
+	return nil
+}
+
+// Append injects a binary blob at the end of the freezer table. The item index
+// is a precautionary parameter to ensure data correctness, but the table will
+// reject already existing data.
+//
+// Note, this method will *not* flush any data to disk so be sure to explicitly
+// fsync before irreversibly deleting data from the database.
+func (t *freezerTable) Append(item uint64, blob []byte) error {
+	// Ensure the table is still accessible
+	if t.offsets == nil || t.content == nil {
+		return errClosed
+	}
+	// Ensure only the next item can be written, nothing else
+	if t.items != item {
+		panic(fmt.Sprintf("appending unexpected item: want %d, have %d", t.items, item))
+	}
+	// Encode the blob and write it into the data file
+	blob = snappy.Encode(nil, blob)
+	if _, err := t.content.Write(blob); err != nil {
+		return err
+	}
+	t.bytes += uint64(len(blob))
+
+	offset := make([]byte, 8)
+	binary.LittleEndian.PutUint64(offset, t.bytes)
+	if _, err := t.offsets.Write(offset); err != nil {
+		return err
+	}
+	t.items++
+
+	t.writeMeter.Mark(int64(len(blob) + 8)) // 8 = 1 x 8 byte offset
+	return nil
+}
+
+// Retrieve looks up the data offset of an item with the given index and retrieves
+// the raw binary blob from the data file.
+func (t *freezerTable) Retrieve(item uint64) ([]byte, error) {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	// Ensure the table and the item is accessible
+	if t.offsets == nil || t.content == nil {
+		return nil, errClosed
+	}
+	if t.items <= item {
+		return nil, errOutOfBounds
+	}
+	// Item reachable, retrieve the data content boundaries
+	offset := make([]byte, 8)
+	if _, err := t.offsets.ReadAt(offset, int64(item*8)); err != nil {
+		return nil, err
+	}
+	start := binary.LittleEndian.Uint64(offset)
+
+	if _, err := t.offsets.ReadAt(offset, int64((item+1)*8)); err != nil {
+		return nil, err
+	}
+	end := binary.LittleEndian.Uint64(offset)
+
+	// Retrieve the data itself, decompress and return
+	blob := make([]byte, end-start)
+	if _, err := t.content.ReadAt(blob, int64(start)); err != nil {
+		return nil, err
+	}
+	t.readMeter.Mark(int64(len(blob) + 16)) // 16 = 2 x 8 byte offset
+	return snappy.Decode(nil, blob)
+}
+
+// Sync pushes any pending data from memory out to disk. This is an expensive
+// operation, so use it with care.
+func (t *freezerTable) Sync() error {
+	if err := t.offsets.Sync(); err != nil {
+		return err
+	}
+	return t.content.Sync()
+}

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -342,9 +342,9 @@ func (t *freezerTable) openFile(num uint32, flag int) (f *os.File, err error) {
 	if f, exist = t.files[num]; !exist {
 		var name string
 		if t.noCompression {
-			name = fmt.Sprintf("%s.%d.rdat", t.name, num)
+			name = fmt.Sprintf("%s.%04d.rdat", t.name, num)
 		} else {
-			name = fmt.Sprintf("%s.%d.cdat", t.name, num)
+			name = fmt.Sprintf("%s.%04d.cdat", t.name, num)
 		}
 		f, err = os.OpenFile(filepath.Join(t.path, name), flag, 0644)
 		if err != nil {
@@ -524,12 +524,19 @@ func (t *freezerTable) printIndex() {
 	fmt.Printf("|-----------------|\n")
 	fmt.Printf("| fileno | offset |\n")
 	fmt.Printf("|--------+--------|\n")
-	for i := uint64(0); err == nil; i++ {
-
+	for i := uint64(0); ; i++ {
 		_, err = t.index.ReadAt(buf, int64(i*indexEntrySize))
+		if err != nil {
+			break
+		}
 		var entry indexEntry
 		entry.unmarshalBinary(buf)
 		fmt.Printf("|  %03d   |  %03d   | \n", entry.filenum, entry.offset)
+		if i > 100 {
+			fmt.Printf(" ... \n")
+			break
+		}
 	}
+	fmt.Printf("|-----------------|\n")
 
 }

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -1,0 +1,511 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rawdb
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/ethereum/go-ethereum/metrics"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func init() {
+	rand.Seed(time.Now().Unix())
+}
+
+// Gets a chunk of data, filled with 'b'
+func getChunk(size int, b byte) []byte {
+	data := make([]byte, size)
+	for i, _ := range data {
+		data[i] = b
+	}
+	return data
+}
+
+func print(t *testing.T, f *freezerTable, item uint64) {
+	a, err := f.Retrieve(item)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Printf("db[%d] =  %x\n", item, a)
+}
+
+// TestFreezerBasics test initializing a freezertable from scratch, writing to the table,
+// and reading it back.
+func TestFreezerBasics(t *testing.T) {
+	t.Parallel()
+	// set cutoff at 50 bytes
+	f, err := newCustomTable(os.TempDir(),
+		fmt.Sprintf("unittest-%d", rand.Uint64()),
+		metrics.NewMeter(), metrics.NewMeter(), 50, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	// Write 15 bytes 255 times, results in 85 files
+	for x := byte(0); x < 255; x++ {
+		data := getChunk(15, x)
+		f.Append(uint64(x), data)
+	}
+
+	//print(t, f, 0)
+	//print(t, f, 1)
+	//print(t, f, 2)
+	//
+	//db[0] =  000000000000000000000000000000
+	//db[1] =  010101010101010101010101010101
+	//db[2] =  020202020202020202020202020202
+
+	for y := byte(0); y < 255; y++ {
+		exp := getChunk(15, y)
+		got, err := f.Retrieve(uint64(y))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, exp) {
+			t.Fatalf("test %d, got \n%x != \n%x", y, got, exp)
+		}
+	}
+}
+
+// TestFreezerBasicsClosing tests same as TestFreezerBasics, but also closes and reopens the freezer between
+// every operation
+func TestFreezerBasicsClosing(t *testing.T) {
+	t.Parallel()
+	// set cutoff at 50 bytes
+	var (
+		fname  = fmt.Sprintf("basics-close-%d", rand.Uint64())
+		m1, m2 = metrics.NewMeter(), metrics.NewMeter()
+		f      *freezerTable
+		err    error
+	)
+	f, err = newCustomTable(os.TempDir(), fname, m1, m2, 50, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Write 15 bytes 255 times, results in 85 files
+	for x := byte(0); x < 255; x++ {
+		data := getChunk(15, x)
+		f.Append(uint64(x), data)
+		f.Close()
+		f, err = newCustomTable(os.TempDir(), fname, m1, m2, 50, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	defer f.Close()
+
+	for y := byte(0); y < 255; y++ {
+		exp := getChunk(15, y)
+		got, err := f.Retrieve(uint64(y))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, exp) {
+			t.Fatalf("test %d, got \n%x != \n%x", y, got, exp)
+		}
+		f.Close()
+		f, err = newCustomTable(os.TempDir(), fname, m1, m2, 50, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestFreezerRepairDanglingHead tests that we can recover if index entries are removed
+func TestFreezerRepairDanglingHead(t *testing.T) {
+	t.Parallel()
+	wm, rm := metrics.NewMeter(), metrics.NewMeter()
+	fname := fmt.Sprintf("dangling_headtest-%d", rand.Uint64())
+
+	{ // Fill table
+		f, err := newCustomTable(os.TempDir(), fname, rm, wm, 50, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Write 15 bytes 255 times
+		for x := byte(0); x < 0xff; x++ {
+			data := getChunk(15, x)
+			f.Append(uint64(x), data)
+		}
+		// The last item should be there
+		if _, err = f.Retrieve(0xfe); err != nil {
+			t.Fatal(err)
+		}
+		f.Close()
+	}
+	// open the index
+	idxFile, err := os.OpenFile(filepath.Join(os.TempDir(), fmt.Sprintf("%s.ridx", fname)), os.O_RDWR, 0644)
+	if err != nil {
+		t.Fatalf("Failed to open index file: %v", err)
+	}
+	// Remove 4 bytes
+	stat, err := idxFile.Stat()
+	if err != nil {
+		t.Fatalf("Failed to stat index file: %v", err)
+	}
+	idxFile.Truncate(stat.Size() - 4)
+	idxFile.Close()
+	// Now open it again
+	{
+		f, err := newCustomTable(os.TempDir(), fname, rm, wm, 50, true)
+		// The last item should be missing
+		if _, err = f.Retrieve(0xff); err == nil {
+			t.Errorf("Expected error for missing index entry")
+		}
+		// The one before should still be there
+		if _, err = f.Retrieve(0xfd); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+	}
+}
+
+// TestFreezerRepairDanglingHeadLarge tests that we can recover if very many index entries are removed
+func TestFreezerRepairDanglingHeadLarge(t *testing.T) {
+	t.Parallel()
+	wm, rm := metrics.NewMeter(), metrics.NewMeter()
+	fname := fmt.Sprintf("dangling_headtest-%d", rand.Uint64())
+
+	{ // Fill a table and close it
+		f, err := newCustomTable(os.TempDir(), fname, wm, rm, 50, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Write 15 bytes 255 times
+		for x := byte(0); x < 0xff; x++ {
+			data := getChunk(15, x)
+			f.Append(uint64(x), data)
+		}
+		// The last item should be there
+		if _, err = f.Retrieve(f.items - 1); err == nil {
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		f.Close()
+	}
+	// open the index
+	idxFile, err := os.OpenFile(filepath.Join(os.TempDir(), fmt.Sprintf("%s.ridx", fname)), os.O_RDWR, 0644)
+	if err != nil {
+		t.Fatalf("Failed to open index file: %v", err)
+	}
+	// Remove everything but the first item, and leave data unaligned
+	// 0-indexEntry, 1-indexEntry, corrupt-indexEntry
+	idxFile.Truncate(indexEntrySize + indexEntrySize + indexEntrySize/2)
+	idxFile.Close()
+	// Now open it again
+	{
+		f, err := newCustomTable(os.TempDir(), fname, rm, wm, 50, true)
+		// The first item should be there
+		if _, err = f.Retrieve(0); err != nil {
+			t.Fatal(err)
+		}
+		// The second item should be missing
+		if _, err = f.Retrieve(1); err == nil {
+			t.Errorf("Expected error for missing index entry")
+		}
+		// We should now be able to store items again, from item = 1
+		for x := byte(1); x < 0xff; x++ {
+			data := getChunk(15, ^x)
+			f.Append(uint64(x), data)
+		}
+		f.Close()
+	}
+	// And if we open it, we should now be able to read all of them (new values)
+	{
+		f, _ := newCustomTable(os.TempDir(), fname, rm, wm, 50, true)
+		for y := byte(1); y < 255; y++ {
+			exp := getChunk(15, ^y)
+			got, err := f.Retrieve(uint64(y))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(got, exp) {
+				t.Fatalf("test %d, got \n%x != \n%x", y, got, exp)
+			}
+		}
+	}
+}
+
+// TestSnappyDetection tests that we fail to open a snappy database and vice versa
+func TestSnappyDetection(t *testing.T) {
+	t.Parallel()
+	wm, rm := metrics.NewMeter(), metrics.NewMeter()
+	fname := fmt.Sprintf("snappytest-%d", rand.Uint64())
+	// Open with snappy
+	{
+		f, err := newCustomTable(os.TempDir(), fname, wm, rm, 50, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Write 15 bytes 255 times
+		for x := byte(0); x < 0xff; x++ {
+			data := getChunk(15, x)
+			f.Append(uint64(x), data)
+		}
+		f.Close()
+	}
+	// Open without snappy
+	{
+		f, err := newCustomTable(os.TempDir(), fname, wm, rm, 50, false)
+		if _, err = f.Retrieve(0); err == nil {
+			f.Close()
+			t.Fatalf("expected empty table")
+		}
+	}
+
+	// Open with snappy
+	{
+		f, err := newCustomTable(os.TempDir(), fname, wm, rm, 50, true)
+		// There should be 255 items
+		if _, err = f.Retrieve(0xfe); err != nil {
+			f.Close()
+			t.Fatalf("expected no error, got %v", err)
+		}
+	}
+
+}
+func assertFileSize(f string, size int64) error {
+	stat, err := os.Stat(f)
+	if err != nil {
+		return err
+	}
+	if stat.Size() != size {
+		return fmt.Errorf("error, expected size %d, got %d", size, stat.Size())
+	}
+	return nil
+
+}
+
+// TestFreezerRepairDanglingIndex checks that if the index has more entries than there are data,
+// the index is repaired
+func TestFreezerRepairDanglingIndex(t *testing.T) {
+	t.Parallel()
+	wm, rm := metrics.NewMeter(), metrics.NewMeter()
+	fname := fmt.Sprintf("dangling_indextest-%d", rand.Uint64())
+
+	{ // Fill a table and close it
+		f, err := newCustomTable(os.TempDir(), fname, wm, rm, 50, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Write 15 bytes 9 times : 150 bytes
+		for x := byte(0); x < 9; x++ {
+			data := getChunk(15, x)
+			f.Append(uint64(x), data)
+		}
+		// The last item should be there
+		if _, err = f.Retrieve(f.items - 1); err != nil {
+			f.Close()
+			t.Fatal(err)
+		}
+		f.Close()
+		// File sizes should be 45, 45, 45 : items[3, 3, 3)
+	}
+	// Crop third file
+	fileToCrop := filepath.Join(os.TempDir(), fmt.Sprintf("%s.2.rdat", fname))
+	// Truncate third file: 45 ,45, 20
+	{
+		if err := assertFileSize(fileToCrop, 45); err != nil {
+			t.Fatal(err)
+		}
+		file, err := os.OpenFile(fileToCrop, os.O_RDWR, 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+		file.Truncate(20)
+		file.Close()
+	}
+	// Open db it again
+	// It should restore the file(s) to
+	// 45, 45, 15
+	// with 3+3+1 items
+	{
+		f, err := newCustomTable(os.TempDir(), fname, wm, rm, 50, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if f.items != 7 {
+			f.Close()
+			t.Fatalf("expected %d items, got %d", 7, f.items)
+		}
+		if err := assertFileSize(fileToCrop, 15); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestFreezerTruncate(t *testing.T) {
+
+	t.Parallel()
+	wm, rm := metrics.NewMeter(), metrics.NewMeter()
+	fname := fmt.Sprintf("truncation-%d", rand.Uint64())
+
+	{ // Fill table
+		f, err := newCustomTable(os.TempDir(), fname, rm, wm, 50, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Write 15 bytes 30 times
+		for x := byte(0); x < 30; x++ {
+			data := getChunk(15, x)
+			f.Append(uint64(x), data)
+		}
+		// The last item should be there
+		if _, err = f.Retrieve(f.items - 1); err != nil {
+			t.Fatal(err)
+		}
+		f.Close()
+	}
+	// Reopen, truncate
+	{
+		f, err := newCustomTable(os.TempDir(), fname, rm, wm, 50, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+		f.truncate(10) // 150 bytes
+		if f.items != 10 {
+			t.Fatalf("expected %d items, got %d", 10, f.items)
+		}
+		// 45, 45, 45, 15 -- bytes should be 15
+		if f.headBytes != 15 {
+			t.Fatalf("expected %d bytes, got %d", 15, f.headBytes)
+		}
+
+	}
+
+}
+
+// TestFreezerRepairFirstFile tests a head file with the very first item only half-written.
+// That will rewind the index, and _should_ truncate the head file
+func TestFreezerRepairFirstFile(t *testing.T) {
+	t.Parallel()
+	wm, rm := metrics.NewMeter(), metrics.NewMeter()
+	fname := fmt.Sprintf("truncationfirst-%d", rand.Uint64())
+	{ // Fill table
+		f, err := newCustomTable(os.TempDir(), fname, rm, wm, 50, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Write 80 bytes, splitting out into two files
+		f.Append(0, getChunk(40, 0xFF))
+		f.Append(1, getChunk(40, 0xEE))
+		// The last item should be there
+		if _, err = f.Retrieve(f.items - 1); err != nil {
+			t.Fatal(err)
+		}
+		f.Close()
+	}
+	// Truncate the file in half
+	fileToCrop := filepath.Join(os.TempDir(), fmt.Sprintf("%s.1.rdat", fname))
+	{
+		if err := assertFileSize(fileToCrop, 40); err != nil {
+			t.Fatal(err)
+		}
+		file, err := os.OpenFile(fileToCrop, os.O_RDWR, 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+		file.Truncate(20)
+		file.Close()
+	}
+	// Reopen
+	{
+		f, err := newCustomTable(os.TempDir(), fname, wm, rm, 50, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if f.items != 1 {
+			f.Close()
+			t.Fatalf("expected %d items, got %d", 0, f.items)
+		}
+		// Write 40 bytes
+		f.Append(1, getChunk(40, 0xDD))
+		f.Close()
+		// Should have been truncated down to zero and then 40 written
+		if err := assertFileSize(fileToCrop, 40); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestFreezerReadAndTruncate tests:
+// - we have a table open
+// - do some reads, so files are open in readonly
+// - truncate so those files are 'removed'
+// - check that we did not keep the rdonly file descriptors
+func TestFreezerReadAndTruncate(t *testing.T) {
+	t.Parallel()
+	wm, rm := metrics.NewMeter(), metrics.NewMeter()
+	fname := fmt.Sprintf("read_truncate-%d", rand.Uint64())
+	{ // Fill table
+		f, err := newCustomTable(os.TempDir(), fname, rm, wm, 50, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Write 15 bytes 30 times
+		for x := byte(0); x < 30; x++ {
+			data := getChunk(15, x)
+			f.Append(uint64(x), data)
+		}
+		// The last item should be there
+		if _, err = f.Retrieve(f.items - 1); err != nil {
+			t.Fatal(err)
+		}
+		f.Close()
+	}
+	// Reopen and read all files
+	{
+		f, err := newCustomTable(os.TempDir(), fname, wm, rm, 50, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if f.items != 30 {
+			f.Close()
+			t.Fatalf("expected %d items, got %d", 0, f.items)
+		}
+		for y := byte(0); y < 30; y++ {
+			f.Retrieve(uint64(y))
+		}
+		// Now, truncate back to zero
+		f.truncate(0)
+		// Write the data again
+		for x := byte(0); x < 30; x++ {
+			data := getChunk(15, ^x)
+			if err := f.Append(uint64(x), data); err != nil {
+				t.Fatalf("error %v", err)
+			}
+		}
+		f.Close()
+	}
+}
+
+// TODO (?)
+// - test that if we remove several head-files, aswell as data last data-file,
+//   the index is truncated accordingly
+// Right now, the freezer would fail on these conditions:
+// 1. have data files d0, d1, d2, d3
+// 2. remove d2,d3
+//
+// However, all 'normal' failure modes arising due to failing to sync() or save a file should be
+// handled already, and the case described above can only (?) happen if an external process/user
+// deletes files from the filesystem.

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -323,7 +323,7 @@ func TestFreezerRepairDanglingIndex(t *testing.T) {
 		// File sizes should be 45, 45, 45 : items[3, 3, 3)
 	}
 	// Crop third file
-	fileToCrop := filepath.Join(os.TempDir(), fmt.Sprintf("%s.2.rdat", fname))
+	fileToCrop := filepath.Join(os.TempDir(), fmt.Sprintf("%s.0002.rdat", fname))
 	// Truncate third file: 45 ,45, 20
 	{
 		if err := assertFileSize(fileToCrop, 45); err != nil {
@@ -418,7 +418,7 @@ func TestFreezerRepairFirstFile(t *testing.T) {
 		f.Close()
 	}
 	// Truncate the file in half
-	fileToCrop := filepath.Join(os.TempDir(), fmt.Sprintf("%s.1.rdat", fname))
+	fileToCrop := filepath.Join(os.TempDir(), fmt.Sprintf("%s.0001.rdat", fname))
 	{
 		if err := assertFileSize(fileToCrop, 40); err != nil {
 			t.Fatal(err)
@@ -519,13 +519,14 @@ func TestOffset(t *testing.T) {
 
 		f.Append(4, getChunk(20, 0xbb))
 		f.Append(5, getChunk(20, 0xaa))
+		f.printIndex()
 		f.Close()
 	}
 	// Now crop it.
 	{
 		// delete files 0 and 1
 		for i := 0; i < 2; i++ {
-			p := filepath.Join(os.TempDir(), fmt.Sprintf("%v.%d.rdat", fname, i))
+			p := filepath.Join(os.TempDir(), fmt.Sprintf("%v.%04d.rdat", fname, i))
 			if err := os.Remove(p); err != nil {
 				t.Fatal(err)
 			}

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -50,6 +50,12 @@ func (t *table) Get(key []byte) ([]byte, error) {
 	return t.db.Get(append([]byte(t.prefix), key...))
 }
 
+// Ancient is a noop passthrough that just forwards the request to the underlying
+// database.
+func (t *table) Ancient(kind string, number uint64) ([]byte, error) {
+	return t.db.Ancient(kind, number)
+}
+
 // Put inserts the given value into the database at a prefixed version of the
 // provided key.
 func (t *table) Put(key []byte, value []byte) error {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -120,7 +120,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	log.Info("Allocated trie memory caches", "clean", common.StorageSize(config.TrieCleanCache)*1024*1024, "dirty", common.StorageSize(config.TrieDirtyCache)*1024*1024)
 
 	// Assemble the Ethereum object
-	chainDb, err := ctx.OpenDatabase("chaindata", config.DatabaseCache, config.DatabaseHandles, "eth/db/chaindata/")
+	chainDb, err := ctx.OpenDatabaseWithFreezer("chaindata", config.DatabaseCache, config.DatabaseHandles, config.DatabaseFreezer, "eth/db/chaindata/")
 	if err != nil {
 		return nil, err
 	}

--- a/eth/config.go
+++ b/eth/config.go
@@ -114,6 +114,7 @@ type Config struct {
 	SkipBcVersionCheck bool `toml:"-"`
 	DatabaseHandles    int  `toml:"-"`
 	DatabaseCache      int
+	DatabaseFreezer    string
 
 	TrieCleanCache int
 	TrieDirtyCache int

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -80,6 +80,13 @@ type AncientReader interface {
 	Ancienter
 }
 
+// AncientStore contains all the methods required to allow handling different
+// ancient data stores backing immutable chain data store.
+type AncientStore interface {
+	Ancienter
+	io.Closer
+}
+
 // Database contains all the methods required by the high level database to not
 // only access the key-value data store but also the chain freezer.
 type Database interface {

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -67,10 +67,23 @@ type KeyValueStore interface {
 	io.Closer
 }
 
+// Ancienter wraps the Ancient method for a backing immutable chain data store.
+type Ancienter interface {
+	// Ancient retrieves an ancient binary blob from the append-only immutable files.
+	Ancient(kind string, number uint64) ([]byte, error)
+}
+
+// AncientReader contains the methods required to access both key-value as well as
+// immutable ancient data.
+type AncientReader interface {
+	Reader
+	Ancienter
+}
+
 // Database contains all the methods required by the high level database to not
 // only access the key-value data store but also the chain freezer.
 type Database interface {
-	Reader
+	AncientReader
 	Writer
 	Batcher
 	Iteratee

--- a/node/node.go
+++ b/node/node.go
@@ -614,6 +614,26 @@ func (n *Node) OpenDatabase(name string, cache, handles int, namespace string) (
 	return rawdb.NewLevelDBDatabase(n.config.ResolvePath(name), cache, handles, namespace)
 }
 
+// OpenDatabaseWithFreezer opens an existing database with the given name (or
+// creates one if no previous can be found) from within the node's data directory,
+// also attaching a chain freezer to it that moves ancient chain data from the
+// database to immutable append-only files. If the node is an ephemeral one, a
+// memory database is returned.
+func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer, namespace string) (ethdb.Database, error) {
+	if n.config.DataDir == "" {
+		return rawdb.NewMemoryDatabase(), nil
+	}
+	root := n.config.ResolvePath(name)
+
+	switch {
+	case freezer == "":
+		freezer = filepath.Join(root, "ancient")
+	case !filepath.IsAbs(freezer):
+		freezer = n.config.ResolvePath(freezer)
+	}
+	return rawdb.NewLevelDBDatabaseWithFreezer(root, cache, handles, freezer, namespace)
+}
+
 // ResolvePath returns the absolute path of a resource in the instance directory.
 func (n *Node) ResolvePath(x string) string {
 	return n.config.ResolvePath(x)

--- a/node/service.go
+++ b/node/service.go
@@ -17,6 +17,7 @@
 package node
 
 import (
+	"path/filepath"
 	"reflect"
 
 	"github.com/ethereum/go-ethereum/accounts"
@@ -44,11 +45,27 @@ func (ctx *ServiceContext) OpenDatabase(name string, cache int, handles int, nam
 	if ctx.config.DataDir == "" {
 		return rawdb.NewMemoryDatabase(), nil
 	}
-	db, err := rawdb.NewLevelDBDatabase(ctx.config.ResolvePath(name), cache, handles, namespace)
-	if err != nil {
-		return nil, err
+	return rawdb.NewLevelDBDatabase(ctx.config.ResolvePath(name), cache, handles, namespace)
+}
+
+// OpenDatabaseWithFreezer opens an existing database with the given name (or
+// creates one if no previous can be found) from within the node's data directory,
+// also attaching a chain freezer to it that moves ancient chain data from the
+// database to immutable append-only files. If the node is an ephemeral one, a
+// memory database is returned.
+func (ctx *ServiceContext) OpenDatabaseWithFreezer(name string, cache int, handles int, freezer string, namespace string) (ethdb.Database, error) {
+	if ctx.config.DataDir == "" {
+		return rawdb.NewMemoryDatabase(), nil
 	}
-	return db, nil
+	root := ctx.config.ResolvePath(name)
+
+	switch {
+	case freezer == "":
+		freezer = filepath.Join(root, "ancient")
+	case !filepath.IsAbs(freezer):
+		freezer = ctx.config.ResolvePath(freezer)
+	}
+	return rawdb.NewLevelDBDatabaseWithFreezer(root, cache, handles, freezer, namespace)
 }
 
 // ResolvePath resolves a user path into the data directory if that was relative


### PR DESCRIPTION
This PR 

- Fixes a failure to unlock a read-mutex at exit with error
- Adds a basic future ability to delete old items. 
- Changes file naming to be `ls`-friendly with four digit file numbers. 

Regarding the deletion of old files, here's how it would work. The first item in the index is usually `(0,0)`, but when doing a tail-truncate, that item takes on a different meaning. 
`fileno := count_of_deleted_items` and `offset = id of first datafile`. 
The implementation depends on the fact that whenever an item is read, if the two offsets point to different files, the first index filenum and offset will be ignored, since entries do not overlap files. 
This way of doing tail-truncation thus depends on: `number of deleted items != id of first file`. Which should always hold, unless the configuration is such that the db always only fit one entry into each file. 

If this is the index before tail-truncation, where we have `6` items (thus `7` indices), 
```
|-----------------|
| fileno | offset |
|--------+--------|
|  000   |  000   | 
|  000   |  020   | 
|  000   |  040   | 
|  001   |  020   | 
|  001   |  040   | 
|  002   |  020   | 
|  002   |  040   | 
|-----------------|
```
... and remove the oldest `4` indices, then we need to put `4` into `fileno` to denote the offset for items. Also, we put `2` into the `offset`, to indicate that the file `..2` is the first one, and earlier files should not be `preopen`ed by the database.
```
|-----------------|
| fileno | offset |
|--------+--------|
|  004   |  002   | 
|  002   |  020   | 
|  002   |  040   | 
|-----------------|
```

However, the freezer already "supports" tail truncation, simply by deleting the old files. In that case, the index file needs to be left unmodified. So what this PR does, is allow for future tail-truncation of the index file itself. 