### PR TITLE
core/state/snapshot: experiment with binary encoder for journal

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -119,7 +119,7 @@ func (b *SimulatedBackend) rollback() {
 	statedb, _ := b.blockchain.State()
 
 	b.pendingBlock = blocks[0]
-	b.pendingState, _ = state.New(b.pendingBlock.Root(), statedb.Database())
+	b.pendingState, _ = state.New(b.pendingBlock.Root(), statedb.Database(), nil)
 }
 
 // CodeAt returns the code associated with a certain account in the blockchain.
@@ -347,7 +347,7 @@ func (b *SimulatedBackend) SendTransaction(ctx context.Context, tx *types.Transa
 	statedb, _ := b.blockchain.State()
 
 	b.pendingBlock = blocks[0]
-	b.pendingState, _ = state.New(b.pendingBlock.Root(), statedb.Database())
+	b.pendingState, _ = state.New(b.pendingBlock.Root(), statedb.Database(), nil)
 	return nil
 }
 
@@ -432,7 +432,7 @@ func (b *SimulatedBackend) AdjustTime(adjustment time.Duration) error {
 	statedb, _ := b.blockchain.State()
 
 	b.pendingBlock = blocks[0]
-	b.pendingState, _ = state.New(b.pendingBlock.Root(), statedb.Database())
+	b.pendingState, _ = state.New(b.pendingBlock.Root(), statedb.Database(), nil)
 
 	return nil
 }

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -100,10 +100,10 @@ func runCmd(ctx *cli.Context) error {
 		genesisConfig = gen
 		db := rawdb.NewMemoryDatabase()
 		genesis := gen.ToBlock(db)
-		statedb, _ = state.New(genesis.Root(), state.NewDatabase(db))
+		statedb, _ = state.New(genesis.Root(), state.NewDatabase(db), nil)
 		chainConfig = gen.Config
 	} else {
-		statedb, _ = state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()))
+		statedb, _ = state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
 		genesisConfig = new(core.Genesis)
 	}
 	if ctx.GlobalString(SenderFlag.Name) != "" {

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -521,7 +521,7 @@ func dump(ctx *cli.Context) error {
 			fmt.Println("{}")
 			utils.Fatalf("block not found")
 		} else {
-			state, err := state.New(block.Root(), state.NewDatabase(chainDb))
+			state, err := state.New(block.Root(), state.NewDatabase(chainDb), nil)
 			if err != nil {
 				utils.Fatalf("could not create new state: %v", err)
 			}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -303,8 +303,6 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 	if bc.snaps, err = snapshot.New(bc.db, "snapshot.rlp", head.NumberU64(), head.Root()); err != nil {
 		return nil, err
 	}
-	fmt.Println(bc.snaps)
-
 	// Take ownership of this particular state
 	go bc.update()
 	return bc, nil
@@ -832,6 +830,10 @@ func (bc *BlockChain) Stop() {
 
 	bc.wg.Wait()
 
+	// Ensure that the entirety of the state snapshot is journalled to disk.
+	if err := bc.snaps.Journal(bc.CurrentBlock().Root()); err != nil {
+		log.Error("Failed to journal state snapshot", "err", err)
+	}
 	// Ensure the state of a recent block is also stored to disk before exiting.
 	// We're writing three different states to catch different restart scenarios:
 	//  - HEAD:     So we don't need to reprocess any blocks in the general case

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -59,6 +60,10 @@ var (
 	storageHashTimer   = metrics.NewRegisteredTimer("chain/storage/hashes", nil)
 	storageUpdateTimer = metrics.NewRegisteredTimer("chain/storage/updates", nil)
 	storageCommitTimer = metrics.NewRegisteredTimer("chain/storage/commits", nil)
+
+	snapshotAccountReadTimer = metrics.NewRegisteredTimer("chain/snapshot/accountreads", nil)
+	snapshotStorageReadTimer = metrics.NewRegisteredTimer("chain/snapshot/storagereads", nil)
+	snapshotCommitTimer      = metrics.NewRegisteredTimer("chain/snapshot/commits", nil)
 
 	blockInsertTimer     = metrics.NewRegisteredTimer("chain/inserts", nil)
 	blockValidationTimer = metrics.NewRegisteredTimer("chain/validation", nil)
@@ -134,9 +139,10 @@ type BlockChain struct {
 	chainConfig *params.ChainConfig // Chain & network configuration
 	cacheConfig *CacheConfig        // Cache configuration for pruning
 
-	db     ethdb.Database // Low level persistent database to store final content in
-	triegc *prque.Prque   // Priority queue mapping block numbers to tries to gc
-	gcproc time.Duration  // Accumulates canonical block processing for trie dumping
+	db     ethdb.Database         // Low level persistent database to store final content in
+	snaps  *snapshot.SnapshotTree // Snapshot tree for fast trie leaf access
+	triegc *prque.Prque           // Priority queue mapping block numbers to tries to gc
+	gcproc time.Duration          // Accumulates canonical block processing for trie dumping
 
 	hc            *HeaderChain
 	rmLogsFeed    event.Feed
@@ -292,6 +298,13 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 			}
 		}
 	}
+	// Load any existing snapshot, regenerating it if loading failed
+	head := bc.CurrentBlock()
+	if bc.snaps, err = snapshot.New(bc.db, "snapshot.rlp", head.NumberU64(), head.Root()); err != nil {
+		return nil, err
+	}
+	fmt.Println(bc.snaps)
+
 	// Take ownership of this particular state
 	go bc.update()
 	return bc, nil
@@ -338,7 +351,7 @@ func (bc *BlockChain) loadLastState() error {
 		return bc.Reset()
 	}
 	// Make sure the state associated with the block is available
-	if _, err := state.New(currentBlock.Root(), bc.stateCache); err != nil {
+	if _, err := state.New(currentBlock.Root(), bc.stateCache, bc.snaps); err != nil {
 		// Dangling block without a state associated, init from scratch
 		log.Warn("Head state missing, repairing chain", "number", currentBlock.Number(), "hash", currentBlock.Hash())
 		if err := bc.repair(&currentBlock); err != nil {
@@ -400,7 +413,7 @@ func (bc *BlockChain) SetHead(head uint64) error {
 			if newHeadBlock == nil {
 				newHeadBlock = bc.genesisBlock
 			} else {
-				if _, err := state.New(newHeadBlock.Root(), bc.stateCache); err != nil {
+				if _, err := state.New(newHeadBlock.Root(), bc.stateCache, bc.snaps); err != nil {
 					// Rewound state missing, rolled back to before pivot, reset to genesis
 					newHeadBlock = bc.genesisBlock
 				}
@@ -513,7 +526,7 @@ func (bc *BlockChain) State() (*state.StateDB, error) {
 
 // StateAt returns a new mutable state based on a particular point in time.
 func (bc *BlockChain) StateAt(root common.Hash) (*state.StateDB, error) {
-	return state.New(root, bc.stateCache)
+	return state.New(root, bc.stateCache, bc.snaps)
 }
 
 // StateCache returns the caching database underpinning the blockchain instance.
@@ -564,7 +577,7 @@ func (bc *BlockChain) ResetWithGenesisBlock(genesis *types.Block) error {
 func (bc *BlockChain) repair(head **types.Block) error {
 	for {
 		// Abort if we've rewound to a head block that does have associated state
-		if _, err := state.New((*head).Root(), bc.stateCache); err == nil {
+		if _, err := state.New((*head).Root(), bc.stateCache, bc.snaps); err == nil {
 			log.Info("Rewound blockchain to past state", "number", (*head).Number(), "hash", (*head).Hash())
 			return nil
 		}
@@ -1061,7 +1074,6 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 				}
 				// Don't collect too much in-memory, write it out every 100K blocks
 				if len(deleted) > 100000 {
-
 					// Sync the ancient store explicitly to ensure all data has been flushed to disk.
 					if err := bc.db.Sync(); err != nil {
 						return 0, err
@@ -1605,7 +1617,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 		if parent == nil {
 			parent = bc.GetHeader(block.ParentHash(), block.NumberU64()-1)
 		}
-		statedb, err := state.New(parent.Root, bc.stateCache)
+		statedb, err := state.New(parent.Root, bc.stateCache, bc.snaps)
 		if err != nil {
 			return it.index, events, coalescedLogs, err
 		}
@@ -1616,7 +1628,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 		if !bc.cacheConfig.TrieCleanNoPrefetch {
 			if followup, err := it.peek(); followup != nil && err == nil {
 				go func(start time.Time) {
-					throwaway, _ := state.New(parent.Root, bc.stateCache)
+					throwaway, _ := state.New(parent.Root, bc.stateCache, bc.snaps)
 					bc.prefetcher.Prefetch(followup, throwaway, bc.vmConfig, &followupInterrupt)
 
 					blockPrefetchExecuteTimer.Update(time.Since(start))
@@ -1635,14 +1647,16 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 			return it.index, events, coalescedLogs, err
 		}
 		// Update the metrics touched during block processing
-		accountReadTimer.Update(statedb.AccountReads)     // Account reads are complete, we can mark them
-		storageReadTimer.Update(statedb.StorageReads)     // Storage reads are complete, we can mark them
-		accountUpdateTimer.Update(statedb.AccountUpdates) // Account updates are complete, we can mark them
-		storageUpdateTimer.Update(statedb.StorageUpdates) // Storage updates are complete, we can mark them
+		accountReadTimer.Update(statedb.AccountReads)                 // Account reads are complete, we can mark them
+		storageReadTimer.Update(statedb.StorageReads)                 // Storage reads are complete, we can mark them
+		accountUpdateTimer.Update(statedb.AccountUpdates)             // Account updates are complete, we can mark them
+		storageUpdateTimer.Update(statedb.StorageUpdates)             // Storage updates are complete, we can mark them
+		snapshotAccountReadTimer.Update(statedb.SnapshotAccountReads) // Account reads are complete, we can mark them
+		snapshotStorageReadTimer.Update(statedb.SnapshotStorageReads) // Storage reads are complete, we can mark them
 
 		triehash := statedb.AccountHashes + statedb.StorageHashes // Save to not double count in validation
-		trieproc := statedb.AccountReads + statedb.AccountUpdates
-		trieproc += statedb.StorageReads + statedb.StorageUpdates
+		trieproc := statedb.SnapshotAccountReads + statedb.AccountReads + statedb.AccountUpdates
+		trieproc += statedb.SnapshotStorageReads + statedb.StorageReads + statedb.StorageUpdates
 
 		blockExecutionTimer.Update(time.Since(substart) - trieproc - triehash)
 
@@ -1671,10 +1685,11 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 		atomic.StoreUint32(&followupInterrupt, 1)
 
 		// Update the metrics touched during block commit
-		accountCommitTimer.Update(statedb.AccountCommits) // Account commits are complete, we can mark them
-		storageCommitTimer.Update(statedb.StorageCommits) // Storage commits are complete, we can mark them
+		accountCommitTimer.Update(statedb.AccountCommits)   // Account commits are complete, we can mark them
+		storageCommitTimer.Update(statedb.StorageCommits)   // Storage commits are complete, we can mark them
+		snapshotCommitTimer.Update(statedb.SnapshotCommits) // Snapshot commits are complete, we can mark them
 
-		blockWriteTimer.Update(time.Since(substart) - statedb.AccountCommits - statedb.StorageCommits)
+		blockWriteTimer.Update(time.Since(substart) - statedb.AccountCommits - statedb.StorageCommits - statedb.SnapshotCommits)
 		blockInsertTimer.UpdateSince(start)
 
 		switch status {

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -228,7 +228,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 		return nil, nil
 	}
 	for i := 0; i < n; i++ {
-		statedb, err := state.New(parent.Root(), state.NewDatabase(db))
+		statedb, err := state.New(parent.Root(), state.NewDatabase(db), nil)
 		if err != nil {
 			panic(err)
 		}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -178,7 +178,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *Genesis, override
 	// We have the genesis block in database(perhaps in ancient database)
 	// but the corresponding state is missing.
 	header := rawdb.ReadHeader(db, stored, 0)
-	if _, err := state.New(header.Root, state.NewDatabaseWithCache(db, 0)); err != nil {
+	if _, err := state.New(header.Root, state.NewDatabaseWithCache(db, 0), nil); err != nil {
 		if genesis == nil {
 			genesis = DefaultGenesisBlock()
 		}
@@ -253,7 +253,7 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 	if db == nil {
 		db = rawdb.NewMemoryDatabase()
 	}
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db), nil)
 	for addr, account := range g.Alloc {
 		statedb.AddBalance(addr, account.Balance)
 		statedb.SetCode(addr, account.Code)

--- a/core/rawdb/accessors_snapshot.go
+++ b/core/rawdb/accessors_snapshot.go
@@ -91,3 +91,9 @@ func DeleteStorageSnapshot(db ethdb.KeyValueWriter, accountHash, storageHash com
 		log.Crit("Failed to delete storage snapshot", "err", err)
 	}
 }
+
+// IterateStorageSnapshots returns an iterator for walking the entire storage
+// space of a specific account.
+func IterateStorageSnapshots(db ethdb.Iteratee, accountHash common.Hash) ethdb.Iterator {
+	return db.NewIteratorWithPrefix(storageSnapshotsKey(accountHash))
+}

--- a/core/rawdb/accessors_snapshot.go
+++ b/core/rawdb/accessors_snapshot.go
@@ -1,0 +1,93 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rawdb
+
+import (
+	"encoding/binary"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// ReadSnapshotBlock retrieves the number and root of the block whose state is
+// contained in the persisted snapshot.
+func ReadSnapshotBlock(db ethdb.KeyValueReader) (uint64, common.Hash) {
+	data, _ := db.Get(snapshotBlockKey)
+	if len(data) != 8+common.HashLength {
+		return 0, common.Hash{}
+	}
+	return binary.BigEndian.Uint64(data[:8]), common.BytesToHash(data[8:])
+}
+
+// WriteSnapshotBlock stores the number and root of the block whose state is
+// contained in the persisted snapshot.
+func WriteSnapshotBlock(db ethdb.KeyValueWriter, number uint64, root common.Hash) {
+	if err := db.Put(snapshotBlockKey, append(encodeBlockNumber(number), root.Bytes()...)); err != nil {
+		log.Crit("Failed to store snapsnot block's number and root", "err", err)
+	}
+}
+
+// DeleteSnapshotBlock deletes the number and hash of the block whose state is
+// contained in the persisted snapshot. Since snapshots are not immutable, this
+// method can be used during updates, so a crash or failure will mark the entire
+// snapshot invalid.
+func DeleteSnapshotBlock(db ethdb.KeyValueWriter) {
+	if err := db.Delete(snapshotBlockKey); err != nil {
+		log.Crit("Failed to remove snapsnot block's number and hash", "err", err)
+	}
+}
+
+// ReadAccountSnapshot retrieves the snapshot entry of an account trie leaf.
+func ReadAccountSnapshot(db ethdb.KeyValueReader, hash common.Hash) []byte {
+	data, _ := db.Get(accountSnapshotKey(hash))
+	return data
+}
+
+// WriteAccountSnapshot stores the snapshot entry of an account trie leaf.
+func WriteAccountSnapshot(db ethdb.KeyValueWriter, hash common.Hash, entry []byte) {
+	if err := db.Put(accountSnapshotKey(hash), entry); err != nil {
+		log.Crit("Failed to store account snapshot", "err", err)
+	}
+}
+
+// DeleteAccountSnapshot removes the snapshot entry of an account trie leaf.
+func DeleteAccountSnapshot(db ethdb.KeyValueWriter, hash common.Hash) {
+	if err := db.Delete(accountSnapshotKey(hash)); err != nil {
+		log.Crit("Failed to delete account snapshot", "err", err)
+	}
+}
+
+// ReadStorageSnapshot retrieves the snapshot entry of an storage trie leaf.
+func ReadStorageSnapshot(db ethdb.KeyValueReader, accountHash, storageHash common.Hash) []byte {
+	data, _ := db.Get(storageSnapshotKey(accountHash, storageHash))
+	return data
+}
+
+// WriteStorageSnapshot stores the snapshot entry of an storage trie leaf.
+func WriteStorageSnapshot(db ethdb.KeyValueWriter, accountHash, storageHash common.Hash, entry []byte) {
+	if err := db.Put(storageSnapshotKey(accountHash, storageHash), entry); err != nil {
+		log.Crit("Failed to store storage snapshot", "err", err)
+	}
+}
+
+// DeleteStorageSnapshot removes the snapshot entry of an storage trie leaf.
+func DeleteStorageSnapshot(db ethdb.KeyValueWriter, accountHash, storageHash common.Hash) {
+	if err := db.Delete(storageSnapshotKey(accountHash, storageHash)); err != nil {
+		log.Crit("Failed to delete storage snapshot", "err", err)
+	}
+}

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -240,6 +240,8 @@ func InspectDatabase(db ethdb.Database) error {
 		hashNumPairing  common.StorageSize
 		trieSize        common.StorageSize
 		txlookupSize    common.StorageSize
+		accountSnapSize common.StorageSize
+		storageSnapSize common.StorageSize
 		preimageSize    common.StorageSize
 		bloomBitsSize   common.StorageSize
 		cliqueSnapsSize common.StorageSize
@@ -281,6 +283,10 @@ func InspectDatabase(db ethdb.Database) error {
 			receiptSize += size
 		case bytes.HasPrefix(key, txLookupPrefix) && len(key) == (len(txLookupPrefix)+common.HashLength):
 			txlookupSize += size
+		case bytes.HasPrefix(key, StateSnapshotPrefix) && len(key) == (len(StateSnapshotPrefix)+common.HashLength):
+			accountSnapSize += size
+		case bytes.HasPrefix(key, StateSnapshotPrefix) && len(key) == (len(StateSnapshotPrefix)+2*common.HashLength):
+			storageSnapSize += size
 		case bytes.HasPrefix(key, preimagePrefix) && len(key) == (len(preimagePrefix)+common.HashLength):
 			preimageSize += size
 		case bytes.HasPrefix(key, bloomBitsPrefix) && len(key) == (len(bloomBitsPrefix)+10+common.HashLength):
@@ -332,6 +338,8 @@ func InspectDatabase(db ethdb.Database) error {
 		{"Key-Value store", "Bloombit index", bloomBitsSize.String()},
 		{"Key-Value store", "Trie nodes", trieSize.String()},
 		{"Key-Value store", "Trie preimages", preimageSize.String()},
+		{"Key-Value store", "Account snapshot", accountSnapSize.String()},
+		{"Key-Value store", "Storage snapshot", storageSnapSize.String()},
 		{"Key-Value store", "Clique snapshots", cliqueSnapsSize.String()},
 		{"Key-Value store", "Singleton metadata", metadata.String()},
 		{"Ancient store", "Headers", ancientHeaders.String()},

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -41,6 +41,9 @@ var (
 	// fastTrieProgressKey tracks the number of trie entries imported during fast sync.
 	fastTrieProgressKey = []byte("TrieSync")
 
+	// snapshotBlockKey tracks the number and hash of the last snapshot.
+	snapshotBlockKey = []byte("SnapshotBlock")
+
 	// Data item prefixes (use single byte to avoid mixing data types, avoid `i`, used for indexes).
 	headerPrefix       = []byte("h") // headerPrefix + num (uint64 big endian) + hash -> header
 	headerTDSuffix     = []byte("t") // headerPrefix + num (uint64 big endian) + hash + headerTDSuffix -> td
@@ -50,8 +53,9 @@ var (
 	blockBodyPrefix     = []byte("b") // blockBodyPrefix + num (uint64 big endian) + hash -> block body
 	blockReceiptsPrefix = []byte("r") // blockReceiptsPrefix + num (uint64 big endian) + hash -> block receipts
 
-	txLookupPrefix  = []byte("l") // txLookupPrefix + hash -> transaction/receipt lookup metadata
-	bloomBitsPrefix = []byte("B") // bloomBitsPrefix + bit (uint16 big endian) + section (uint64 big endian) + hash -> bloom bits
+	txLookupPrefix      = []byte("l") // txLookupPrefix + hash -> transaction/receipt lookup metadata
+	bloomBitsPrefix     = []byte("B") // bloomBitsPrefix + bit (uint16 big endian) + section (uint64 big endian) + hash -> bloom bits
+	StateSnapshotPrefix = []byte("s") // StateSnapshotPrefix + account hash [+ storage hash] -> account/storage trie value
 
 	preimagePrefix = []byte("secure-key-")      // preimagePrefix + hash -> preimage
 	configPrefix   = []byte("ethereum-config-") // config prefix for the db
@@ -143,6 +147,16 @@ func blockReceiptsKey(number uint64, hash common.Hash) []byte {
 // txLookupKey = txLookupPrefix + hash
 func txLookupKey(hash common.Hash) []byte {
 	return append(txLookupPrefix, hash.Bytes()...)
+}
+
+// accountSnapshotKey = StateSnapshotPrefix + hash
+func accountSnapshotKey(hash common.Hash) []byte {
+	return append(StateSnapshotPrefix, hash.Bytes()...)
+}
+
+// storageSnapshotKey = StateSnapshotPrefix + account hash + storage hash
+func storageSnapshotKey(accountHash, storageHash common.Hash) []byte {
+	return append(append(StateSnapshotPrefix, accountHash.Bytes()...), storageHash.Bytes()...)
 }
 
 // bloomBitsKey = bloomBitsPrefix + bit (uint16 big endian) + section (uint64 big endian) + hash

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -159,6 +159,11 @@ func storageSnapshotKey(accountHash, storageHash common.Hash) []byte {
 	return append(append(StateSnapshotPrefix, accountHash.Bytes()...), storageHash.Bytes()...)
 }
 
+// storageSnapshotsKey = StateSnapshotPrefix + account hash + storage hash
+func storageSnapshotsKey(accountHash common.Hash) []byte {
+	return append(StateSnapshotPrefix, accountHash.Bytes()...)
+}
+
 // bloomBitsKey = bloomBitsPrefix + bit (uint16 big endian) + section (uint64 big endian) + hash
 func bloomBitsKey(bit uint, section uint64, hash common.Hash) []byte {
 	key := append(append(bloomBitsPrefix, make([]byte, 10)...), hash.Bytes()...)

--- a/core/state/snapshot/account.go
+++ b/core/state/snapshot/account.go
@@ -1,0 +1,54 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshot
+
+import (
+	"bytes"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// Account is a slim version of a state.Account, where the root and code hash
+// are replaced with a nil byte slice for empty accounts.
+type Account struct {
+	Nonce    uint64
+	Balance  *big.Int
+	Root     []byte
+	CodeHash []byte
+}
+
+// AccountRLP converts a state.Account content into a slim snapshot version RLP
+// encoded.
+func AccountRLP(nonce uint64, balance *big.Int, root common.Hash, codehash []byte) []byte {
+	slim := Account{
+		Nonce:   nonce,
+		Balance: balance,
+	}
+	if root != emptyRoot {
+		slim.Root = root[:]
+	}
+	if !bytes.Equal(codehash, emptyCode[:]) {
+		slim.CodeHash = codehash
+	}
+	data, err := rlp.EncodeToBytes(slim)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}

--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -227,9 +227,6 @@ func (dl *diffLayer) flatten() snapshot {
 // This is meant to be used during shutdown to persist the snapshot without
 // flattening everything down (bad for reorgs).
 func (dl *diffLayer) Journal() error {
-	dl.lock.RLock()
-	defer dl.lock.RUnlock()
-
 	writer, err := dl.journal()
 	if err != nil {
 		return err

--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -40,6 +40,7 @@ type diffLayer struct {
 
 	number uint64      // Block number to which this snapshot diff belongs to
 	root   common.Hash // Root hash to which this snapshot diff belongs to
+	stale  bool        // Signals that the layer became stale (state progressed)
 
 	accountList []common.Hash                          // List of account for iteration. If it exists, it's sorted, otherwise it's nil
 	accountData map[common.Hash][]byte                 // Keyed accounts for direct retrival (nil means deleted)
@@ -101,28 +102,36 @@ func (dl *diffLayer) Info() (uint64, common.Hash) {
 
 // Account directly retrieves the account associated with a particular hash in
 // the snapshot slim data format.
-func (dl *diffLayer) Account(hash common.Hash) *Account {
-	data := dl.AccountRLP(hash)
+func (dl *diffLayer) Account(hash common.Hash) (*Account, error) {
+	data, err := dl.AccountRLP(hash)
+	if err != nil {
+		return nil, err
+	}
 	if len(data) == 0 { // can be both nil and []byte{}
-		return nil
+		return nil, nil
 	}
 	account := new(Account)
 	if err := rlp.DecodeBytes(data, account); err != nil {
 		panic(err)
 	}
-	return account
+	return account, nil
 }
 
 // AccountRLP directly retrieves the account RLP associated with a particular
 // hash in the snapshot slim data format.
-func (dl *diffLayer) AccountRLP(hash common.Hash) []byte {
+func (dl *diffLayer) AccountRLP(hash common.Hash) ([]byte, error) {
 	dl.lock.RLock()
 	defer dl.lock.RUnlock()
 
+	// If the layer was flattened into, consider it invalid (any live reference to
+	// the original should be marked as unusable).
+	if dl.stale {
+		return nil, ErrSnapshotStale
+	}
 	// If the account is known locally, return it. Note, a nil account means it was
 	// deleted, and is a different notion than an unknown account!
 	if data, ok := dl.accountData[hash]; ok {
-		return data
+		return data, nil
 	}
 	// Account unknown to this diff, resolve from parent
 	return dl.parent.AccountRLP(hash)
@@ -131,18 +140,23 @@ func (dl *diffLayer) AccountRLP(hash common.Hash) []byte {
 // Storage directly retrieves the storage data associated with a particular hash,
 // within a particular account. If the slot is unknown to this diff, it's parent
 // is consulted.
-func (dl *diffLayer) Storage(accountHash, storageHash common.Hash) []byte {
+func (dl *diffLayer) Storage(accountHash, storageHash common.Hash) ([]byte, error) {
 	dl.lock.RLock()
 	defer dl.lock.RUnlock()
 
+	// If the layer was flattened into, consider it invalid (any live reference to
+	// the original should be marked as unusable).
+	if dl.stale {
+		return nil, ErrSnapshotStale
+	}
 	// If the account is known locally, try to resolve the slot locally. Note, a nil
 	// account means it was deleted, and is a different notion than an unknown account!
 	if storage, ok := dl.storageData[accountHash]; ok {
 		if storage == nil {
-			return nil
+			return nil, nil
 		}
 		if data, ok := storage[storageHash]; ok {
-			return data
+			return data, nil
 		}
 	}
 	// Account - or slot within - unknown to this diff, resolve from parent
@@ -175,13 +189,17 @@ func (dl *diffLayer) Cap(layers int, memory uint64) (uint64, uint64) {
 	case *diskLayer:
 		return parent.number, dl.number
 	case *diffLayer:
+		// Flatten the parent into the grandparent. The flattening internally obtains a
+		// write lock on grandparent.
+		flattened := parent.flatten().(*diffLayer)
+
 		dl.lock.Lock()
 		defer dl.lock.Unlock()
 
-		dl.parent = parent.flatten()
-		if dl.parent.(*diffLayer).memory < memory {
-			diskNumber, _ := parent.parent.Info()
-			return diskNumber, parent.number
+		dl.parent = flattened
+		if flattened.memory < memory {
+			diskNumber, _ := flattened.parent.Info()
+			return diskNumber, flattened.number
 		}
 	default:
 		panic(fmt.Sprintf("unknown data layer: %T", parent))
@@ -198,6 +216,14 @@ func (dl *diffLayer) Cap(layers int, memory uint64) (uint64, uint64) {
 	// Start by temporarily deleting the current snapshot block marker. This
 	// ensures that in the case of a crash, the entire snapshot is invalidated.
 	rawdb.DeleteSnapshotBlock(batch)
+
+	// Mark the original base as stale as we're going to create a new wrapper
+	base.lock.Lock()
+	if base.stale {
+		panic("parent disk layer is stale") // we've committed into the same base from two children, boo
+	}
+	base.stale = true
+	base.lock.Unlock()
 
 	// Push all the accounts into the database
 	for hash, data := range parent.accountData {
@@ -246,15 +272,20 @@ func (dl *diffLayer) Cap(layers int, memory uint64) (uint64, uint64) {
 		}
 	}
 	// Update the snapshot block marker and write any remainder data
-	base.number, base.root = parent.number, parent.root
-
-	rawdb.WriteSnapshotBlock(batch, base.number, base.root)
+	newBase := &diskLayer{
+		root:    parent.root,
+		number:  parent.number,
+		cache:   base.cache,
+		db:      base.db,
+		journal: base.journal,
+	}
+	rawdb.WriteSnapshotBlock(batch, newBase.number, newBase.root)
 	if err := batch.Write(); err != nil {
 		log.Crit("Failed to write leftover snapshot", "err", err)
 	}
-	dl.parent = base
+	dl.parent = newBase
 
-	return base.number, dl.number
+	return newBase.number, dl.number
 }
 
 // flatten pushes all data from this point downwards, flattening everything into
@@ -270,11 +301,21 @@ func (dl *diffLayer) flatten() snapshot {
 	// flatten will realistically only ever merge 1 layer, so there's no need to
 	// be smarter about grouping flattens together).
 	parent = parent.flatten().(*diffLayer)
+
+	parent.lock.Lock()
+	defer parent.lock.Unlock()
+
+	// Before actually writing all our data to the parent, first ensure that the
+	// parent hasn't been 'corrupted' by someone else already flattening into it
+	if parent.stale {
+		panic("parent diff layer is stale") // we've flattened into the same parent from two children, boo
+	}
+	parent.stale = true
+
 	// Overwrite all the updated accounts blindly, merge the sorted list
 	for hash, data := range dl.accountData {
 		parent.accountData[hash] = data
 	}
-
 	// Overwrite all the updates storage slots (individually)
 	for accountHash, storage := range dl.storageData {
 		// If storage didn't exist (or was deleted) in the parent; or if the storage
@@ -291,10 +332,16 @@ func (dl *diffLayer) flatten() snapshot {
 		parent.storageData[accountHash] = comboData
 	}
 	// Return the combo parent
-	parent.number = dl.number
-	parent.root = dl.root
-	parent.memory += dl.memory
-	return parent
+	return &diffLayer{
+		parent:      parent.parent,
+		number:      dl.number,
+		root:        dl.root,
+		storageList: parent.storageList,
+		storageData: parent.storageData,
+		accountList: parent.accountList,
+		accountData: parent.accountData,
+		memory:      parent.memory + dl.memory,
+	}
 }
 
 // Journal commits an entire diff hierarchy to disk into a single journal file.

--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -41,12 +41,10 @@ type diffLayer struct {
 	number uint64      // Block number to which this snapshot diff belongs to
 	root   common.Hash // Root hash to which this snapshot diff belongs to
 
-	accountList   []common.Hash                          // List of account for iteration, might not be sorted yet (lazy)
-	accountSorted bool                                   // Flag whether the account list has alreayd been sorted or not
-	accountData   map[common.Hash][]byte                 // Keyed accounts for direct retrival (nil means deleted)
-	storageList   map[common.Hash][]common.Hash          // List of storage slots for iterated retrievals, one per account
-	storageSorted map[common.Hash]bool                   // Flag whether the storage slot list has alreayd been sorted or not
-	storageData   map[common.Hash]map[common.Hash][]byte // Keyed storage slots for direct retrival. one per account (nil means deleted)
+	accountList []common.Hash                          // List of account for iteration. If it exists, it's sorted, otherwise it's nil
+	accountData map[common.Hash][]byte                 // Keyed accounts for direct retrival (nil means deleted)
+	storageList map[common.Hash][]common.Hash          // List of storage slots for iterated retrievals, one per account. Any existing lists are sorted if non-nil
+	storageData map[common.Hash]map[common.Hash][]byte // Keyed storage slots for direct retrival. one per account (nil means deleted)
 
 	lock sync.RWMutex
 }
@@ -62,21 +60,13 @@ func newDiffLayer(parent snapshot, number uint64, root common.Hash, accounts map
 		accountData: accounts,
 		storageData: storage,
 	}
-	// Fill the account hashes and sort them for the iterator
-	accountList := make([]common.Hash, 0, len(accounts))
-	for hash, data := range accounts {
-		accountList = append(accountList, hash)
+	// Determine mem size
+	for _, data := range accounts {
 		dl.memory += uint64(len(data))
 	}
-	sort.Sort(hashes(accountList))
-	dl.accountList = accountList
-	dl.accountSorted = true
-
-	dl.memory += uint64(len(dl.accountList) * common.HashLength)
 
 	// Fill the storage hashes and sort them for the iterator
-	dl.storageList = make(map[common.Hash][]common.Hash, len(storage))
-	dl.storageSorted = make(map[common.Hash]bool, len(storage))
+	dl.storageList = make(map[common.Hash][]common.Hash)
 
 	for accountHash, slots := range storage {
 		// If the slots are nil, sanity check that it's a deleted account
@@ -93,19 +83,11 @@ func newDiffLayer(parent snapshot, number uint64, root common.Hash, accounts map
 		// account was just updated.
 		if account, ok := accounts[accountHash]; account == nil || !ok {
 			log.Error(fmt.Sprintf("storage in %#x exists, but account nil (exists: %v)", accountHash, ok))
-			//panic(fmt.Sprintf("storage in %#x exists, but account nil (exists: %v)", accountHash, ok))
 		}
-		// Fill the storage hashes for this account and sort them for the iterator
-		storageList := make([]common.Hash, 0, len(slots))
-		for storageHash, data := range slots {
-			storageList = append(storageList, storageHash)
+		// Determine mem size
+		for _, data := range slots {
 			dl.memory += uint64(len(data))
 		}
-		sort.Sort(hashes(storageList))
-		dl.storageList[accountHash] = storageList
-		dl.storageSorted[accountHash] = true
-
-		dl.memory += uint64(len(storageList) * common.HashLength)
 	}
 	dl.memory += uint64(len(dl.storageList) * common.HashLength)
 
@@ -213,7 +195,7 @@ func (dl *diffLayer) Cap(layers int, memory uint64) (uint64, uint64) {
 	parent.lock.RLock()
 	defer parent.lock.RUnlock()
 
-	// Start by temporarilly deleting the current snapshot block marker. This
+	// Start by temporarily deleting the current snapshot block marker. This
 	// ensures that in the case of a crash, the entire snapshot is invalidated.
 	rawdb.DeleteSnapshotBlock(batch)
 
@@ -288,20 +270,16 @@ func (dl *diffLayer) flatten() snapshot {
 	// flatten will realistically only ever merge 1 layer, so there's no need to
 	// be smarter about grouping flattens together).
 	parent = parent.flatten().(*diffLayer)
-
 	// Overwrite all the updated accounts blindly, merge the sorted list
 	for hash, data := range dl.accountData {
 		parent.accountData[hash] = data
 	}
-	parent.accountList = append(parent.accountList, dl.accountList...) // TODO(karalabe): dedup!!
-	parent.accountSorted = false
 
 	// Overwrite all the updates storage slots (individually)
 	for accountHash, storage := range dl.storageData {
 		// If storage didn't exist (or was deleted) in the parent; or if the storage
 		// was freshly deleted in the child, overwrite blindly
 		if parent.storageData[accountHash] == nil || storage == nil {
-			parent.storageList[accountHash] = dl.storageList[accountHash]
 			parent.storageData[accountHash] = storage
 			continue
 		}
@@ -311,8 +289,6 @@ func (dl *diffLayer) flatten() snapshot {
 			comboData[storageHash] = data
 		}
 		parent.storageData[accountHash] = comboData
-		parent.storageList[accountHash] = append(parent.storageList[accountHash], dl.storageList[accountHash]...) // TODO(karalabe): dedup!!
-		parent.storageSorted[accountHash] = false
 	}
 	// Return the combo parent
 	parent.number = dl.number
@@ -334,4 +310,46 @@ func (dl *diffLayer) Journal() error {
 	}
 	writer.Close()
 	return nil
+}
+
+// AccountList returns a sorted list of all accounts in this difflayer.
+func (dl *diffLayer) AccountList() []common.Hash {
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+	if dl.accountList != nil {
+		return dl.accountList
+	}
+	accountList := make([]common.Hash, len(dl.accountData))
+	i := 0
+	for k, _ := range dl.accountData {
+		accountList[i] = k
+		i++
+		// This would be a pretty good opportunity to also
+		// calculate the size, if we want to
+	}
+	sort.Sort(hashes(accountList))
+	dl.accountList = accountList
+	return dl.accountList
+}
+
+// StorageList returns a sorted list of all storage slot hashes
+// in this difflayer for the given account.
+func (dl *diffLayer) StorageList(accountHash common.Hash) []common.Hash {
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+	if dl.storageList[accountHash] != nil {
+		return dl.storageList[accountHash]
+	}
+	accountStorageMap := dl.storageData[accountHash]
+	accountStorageList := make([]common.Hash, len(accountStorageMap))
+	i := 0
+	for k, _ := range accountStorageMap {
+		accountStorageList[i] = k
+		i++
+		// This would be a pretty good opportunity to also
+		// calculate the size, if we want to
+	}
+	sort.Sort(hashes(accountStorageList))
+	dl.storageList[accountHash] = accountStorageList
+	return accountStorageList
 }

--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -1,0 +1,390 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshot
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// diffLayer represents a collection of modifications made to a state snapshot
+// after running a block on top. It contains one sorted list for the account trie
+// and one-one list for each storage tries.
+//
+// The goal of a diff layer is to act as a journal, tracking recent modifications
+// made to the state, that have not yet graduated into a semi-immutable state.
+type diffLayer struct {
+	parent snapshot // Parent snapshot modified by this one, never nil
+	memory uint64   // Approximate guess as to how much memory we use
+
+	number uint64      // Block number to which this snapshot diff belongs to
+	root   common.Hash // Root hash to which this snapshot diff belongs to
+
+	accountList   []common.Hash                          // List of account for iteration, might not be sorted yet (lazy)
+	accountSorted bool                                   // Flag whether the account list has alreayd been sorted or not
+	accountData   map[common.Hash][]byte                 // Keyed accounts for direct retrival (nil means deleted)
+	storageList   map[common.Hash][]common.Hash          // List of storage slots for iterated retrievals, one per account
+	storageSorted map[common.Hash]bool                   // Flag whether the storage slot list has alreayd been sorted or not
+	storageData   map[common.Hash]map[common.Hash][]byte // Keyed storage slots for direct retrival. one per account (nil means deleted)
+
+	lock sync.RWMutex
+}
+
+// newDiffLayer creates a new diff on top of an existing snapshot, whether that's a low
+// level persistent database or a hierarchical diff already.
+func newDiffLayer(parent snapshot, root common.Hash, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte) *diffLayer {
+	// Create the new layer with some pre-allocated data segments
+	parentNumber, _ := parent.Info()
+
+	dl := &diffLayer{
+		parent:      parent,
+		number:      parentNumber + 1,
+		root:        root,
+		accountData: accounts,
+		storageData: storage,
+	}
+	// Fill the account hashes and sort them for the iterator
+	accountList := make([]common.Hash, 0, len(accounts))
+	for hash, data := range accounts {
+		accountList = append(accountList, hash)
+		dl.memory += uint64(len(data))
+	}
+	sort.Sort(hashes(accountList))
+	dl.accountList = accountList
+	dl.accountSorted = true
+
+	dl.memory += uint64(len(dl.accountList) * common.HashLength)
+
+	// Fill the storage hashes and sort them for the iterator
+	dl.storageList = make(map[common.Hash][]common.Hash, len(storage))
+	dl.storageSorted = make(map[common.Hash]bool, len(storage))
+
+	for accountHash, slots := range storage {
+		// If the slots are nil, sanity check that it's a deleted account
+		if slots == nil {
+			// Ensure that the account was just marked as deleted
+			if account, ok := accounts[accountHash]; account != nil || !ok {
+				panic(fmt.Sprintf("storage in %#x nil, but account conflicts (%#x, exists: %v)", accountHash, account, ok))
+			}
+			// Everything ok, store the deletion mark and continue
+			dl.storageList[accountHash] = nil
+			continue
+		}
+		// Storage slots are not nil so entire contract was not deleted, ensure the
+		// account was just updated.
+		if account, ok := accounts[accountHash]; account == nil || !ok {
+			log.Error(fmt.Sprintf("storage in %#x exists, but account nil (exists: %v)", accountHash, ok))
+			//panic(fmt.Sprintf("storage in %#x exists, but account nil (exists: %v)", accountHash, ok))
+		}
+		// Fill the storage hashes for this account and sort them for the iterator
+		storageList := make([]common.Hash, 0, len(slots))
+		for storageHash, data := range slots {
+			storageList = append(storageList, storageHash)
+			dl.memory += uint64(len(data))
+		}
+		sort.Sort(hashes(storageList))
+		dl.storageList[accountHash] = storageList
+		dl.storageSorted[accountHash] = true
+
+		dl.memory += uint64(len(storageList) * common.HashLength)
+	}
+	dl.memory += uint64(len(dl.storageList) * common.HashLength)
+
+	return dl
+}
+
+// loadDiffLayer reads the next sections of a snapshot journal, reconstructing a new
+// diff and verifying that it can be linked to the requested parent.
+func loadDiffLayer(parent snapshot, r io.Reader) (snapshot, error) {
+	// Read the next diff journal entry
+	var (
+		number   uint64
+		root     common.Hash
+		accounts = make(map[common.Hash][]byte)
+		storage  = make(map[common.Hash]map[common.Hash][]byte)
+	)
+	if err := rlp.Decode(r, &number); err != nil {
+		// The first read may fail with EOF, marking the end of the journal
+		if err == io.EOF {
+			return parent, nil
+		}
+		return nil, err
+	}
+	if err := rlp.Decode(r, &root); err != nil {
+		return nil, err
+	}
+	if err := rlp.Decode(r, &accounts); err != nil {
+		return nil, err
+	}
+	if err := rlp.Decode(r, &storage); err != nil {
+		return nil, err
+	}
+	// Validate the block number to avoid state corruption
+	if parentNumber, _ := parent.Info(); number != parentNumber+1 {
+		return nil, fmt.Errorf("snapshot chain broken: block #%dl after #%dl", number, parentNumber)
+	}
+	return loadDiffLayer(newDiffLayer(parent, root, accounts, storage), r)
+}
+
+// Info returns the block number and root hash for which this snapshot was made.
+func (dl *diffLayer) Info() (uint64, common.Hash) {
+	return dl.number, dl.root
+}
+
+// Account directly retrieves the account associated with a particular hash in
+// the snapshot slim data format.
+func (dl *diffLayer) Account(hash common.Hash) *Account {
+	data := dl.AccountRLP(hash)
+	if len(data) == 0 { // can be both nil and []byte{}
+		return nil
+	}
+	account := new(Account)
+	if err := rlp.DecodeBytes(data, account); err != nil {
+		panic(err)
+	}
+	return account
+}
+
+// AccountRLP directly retrieves the account RLP associated with a particular
+// hash in the snapshot slim data format.
+func (dl *diffLayer) AccountRLP(hash common.Hash) []byte {
+	dl.lock.RLock()
+	defer dl.lock.RUnlock()
+
+	// If the account is known locally, return it. Note, a nil account means it was
+	// deleted, and is a different notion than an unknown account!
+	if data, ok := dl.accountData[hash]; ok {
+		return data
+	}
+	// Account unknown to this diff, resolve from parent
+	return dl.parent.AccountRLP(hash)
+}
+
+// Storage directly retrieves the storage data associated with a particular hash,
+// within a particular account. If the slot is unknown to this diff, it's parent
+// is consulted.
+func (dl *diffLayer) Storage(accountHash, storageHash common.Hash) []byte {
+	dl.lock.RLock()
+	defer dl.lock.RUnlock()
+
+	// If the account is known locally, try to resolve the slot locally. Note, a nil
+	// account means it was deleted, and is a different notion than an unknown account!
+	if storage, ok := dl.storageData[accountHash]; ok {
+		if storage == nil {
+			return nil
+		}
+		if data, ok := storage[storageHash]; ok {
+			return data
+		}
+	}
+	// Account - or slot within - unknown to this diff, resolve from parent
+	return dl.parent.Storage(accountHash, storageHash)
+}
+
+// Update creates a new layer on top of the existing snapshot diff tree with
+// the specified data items.
+func (dl *diffLayer) Update(blockRoot common.Hash, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte) *diffLayer {
+	return newDiffLayer(dl, blockRoot, accounts, storage)
+}
+
+// Cap traverses downwards the diff tree until the number of allowed layers are
+// crossed. All diffs beyond the permitted number are flattened downwards. If
+// the layer limit is reached, memory cap is also enforced (but not before). The
+// block numbers for the disk layer and first diff layer are returned for GC.
+func (dl *diffLayer) Cap(layers int, memory uint64) (uint64, uint64) {
+	// Dive until we run out of layers or reach the persistent database
+	if layers > 2 {
+		// If we still have diff layers below, recurse
+		if parent, ok := dl.parent.(*diffLayer); ok {
+			return parent.Cap(layers-1, memory)
+		}
+		// Diff stack too shallow, return block numbers without modifications
+		return dl.parent.(*diskLayer).number, dl.number
+	}
+	// We're out of layers, flatten anything below, stopping if it's the disk or if
+	// the memory limit is not yet exceeded.
+	switch parent := dl.parent.(type) {
+	case *diskLayer:
+		return parent.number, dl.number
+	case *diffLayer:
+		dl.lock.Lock()
+		defer dl.lock.Unlock()
+
+		dl.parent = parent.flatten()
+		if dl.parent.(*diffLayer).memory < memory {
+			diskNumber, _ := parent.parent.Info()
+			return diskNumber, parent.number
+		}
+	default:
+		panic(fmt.Sprintf("unknown data layer: %T", parent))
+	}
+	// If the bottommost layer is larger than our memory cap, persist to disk
+	var (
+		parent = dl.parent.(*diffLayer)
+		base   = parent.parent.(*diskLayer)
+		batch  = base.db.NewBatch()
+	)
+	// Start by temporarilly deleting the current snapshot block marker. This
+	// ensures that in the case of a crash, the entire snapshot is invalidated.
+	rawdb.DeleteSnapshotBlock(batch)
+
+	// Push all the accounts into the database
+	for hash, data := range parent.accountData {
+		rawdb.WriteAccountSnapshot(batch, hash, data)
+		base.cache.Set(string(hash[:]), data)
+
+		if batch.ValueSize() > ethdb.IdealBatchSize {
+			if err := batch.Write(); err != nil {
+				log.Crit("Failed to write account snapshot", "err", err)
+			}
+			batch.Reset()
+		}
+	}
+	// Push all the storage slots into the database
+	for accountHash, storage := range parent.storageData {
+		for storageHash, data := range storage {
+			rawdb.WriteStorageSnapshot(batch, accountHash, storageHash, data)
+			base.cache.Set(string(append(accountHash[:], storageHash[:]...)), data)
+		}
+		if batch.ValueSize() > ethdb.IdealBatchSize {
+			if err := batch.Write(); err != nil {
+				log.Crit("Failed to write storage snapshot", "err", err)
+			}
+			batch.Reset()
+		}
+	}
+	// Update the snapshot block marker and write any remainder data
+	base.number, base.root = parent.number, parent.root
+
+	rawdb.WriteSnapshotBlock(batch, base.number, base.root)
+	if err := batch.Write(); err != nil {
+		log.Crit("Failed to write leftover snapshot", "err", err)
+	}
+	dl.parent = base
+
+	return base.number, dl.number
+}
+
+// flatten pushes all data from this point downwards, flattening everything into
+// a single diff at the bottom. Since usually the lowermost diff is the largest,
+// the flattening bulds up from there in reverse.
+func (dl *diffLayer) flatten() snapshot {
+	// If the parent is not diff, we're the first in line, return unmodified
+	parent, ok := dl.parent.(*diffLayer)
+	if !ok {
+		return dl
+	}
+	// Parent is a diff, flatten it first (note, apart from weird corned cases,
+	// flatten will realistically only ever merge 1 layer, so there's no need to
+	// be smarter about grouping flattens together).
+	parent = parent.flatten().(*diffLayer)
+
+	// Overwrite all the updated accounts blindly, merge the sorted list
+	for hash, data := range dl.accountData {
+		parent.accountData[hash] = data
+	}
+	parent.accountList = append(parent.accountList, dl.accountList...) // TODO(karalabe): dedup!!
+	parent.accountSorted = false
+
+	// Overwrite all the updates storage slots (individually)
+	for accountHash, storage := range dl.storageData {
+		// If storage didn't exist (or was deleted) in the parent; or if the storage
+		// was freshly deleted in the child, overwrite blindly
+		if parent.storageData[accountHash] == nil || storage == nil {
+			parent.storageList[accountHash] = dl.storageList[accountHash]
+			parent.storageData[accountHash] = storage
+			continue
+		}
+		// Storage exists in both parent and child, merge the slots
+		comboData := parent.storageData[accountHash]
+		for storageHash, data := range storage {
+			comboData[storageHash] = data
+		}
+		parent.storageData[accountHash] = comboData
+		parent.storageList[accountHash] = append(parent.storageList[accountHash], dl.storageList[accountHash]...) // TODO(karalabe): dedup!!
+		parent.storageSorted[accountHash] = false
+	}
+	// Return the combo parent
+	parent.number = dl.number
+	parent.root = dl.root
+	parent.memory += dl.memory
+	return parent
+}
+
+// Journal commits an entire diff hierarchy to disk into a single journal file.
+// This is meant to be used during shutdown to persist the snapshot without
+// flattening everything down (bad for reorgs).
+func (dl *diffLayer) Journal() error {
+	dl.lock.RLock()
+	defer dl.lock.RUnlock()
+
+	writer, err := dl.journal()
+	if err != nil {
+		return err
+	}
+	writer.Close()
+	return nil
+}
+
+// journal is the internal version of Journal that also returns the journal file
+// so subsequent layers know where to write to.
+func (dl *diffLayer) journal() (io.WriteCloser, error) {
+	// If we've reached the bottom, open the journal
+	var writer io.WriteCloser
+	if parent, ok := dl.parent.(*diskLayer); ok {
+		file, err := os.Create(parent.journal)
+		if err != nil {
+			return nil, err
+		}
+		writer = file
+	}
+	// If we haven't reached the bottom yet, journal the parent first
+	if writer == nil {
+		file, err := dl.parent.(*diffLayer).journal()
+		if err != nil {
+			return nil, err
+		}
+		writer = file
+	}
+	// Everything below was journalled, persist this layer too
+	if err := rlp.Encode(writer, dl.number); err != nil {
+		writer.Close()
+		return nil, err
+	}
+	if err := rlp.Encode(writer, dl.root); err != nil {
+		writer.Close()
+		return nil, err
+	}
+	if err := rlp.Encode(writer, dl.accountData); err != nil {
+		writer.Close()
+		return nil, err
+	}
+	if err := rlp.Encode(writer, dl.storageData); err != nil {
+		writer.Close()
+		return nil, err
+	}
+	return writer, nil
+}

--- a/core/state/snapshot/difflayer_journal.go
+++ b/core/state/snapshot/difflayer_journal.go
@@ -1,0 +1,140 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshot
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// journalAccount is an account entry in a diffLayer's disk journal.
+type journalAccount struct {
+	Hash common.Hash
+	Blob []byte
+}
+
+// journalStorage is an account's storage map in a diffLayer's disk journal.
+type journalStorage struct {
+	Hash common.Hash
+	Keys []common.Hash
+	Vals [][]byte
+}
+
+// loadDiffLayer reads the next sections of a snapshot journal, reconstructing a new
+// diff and verifying that it can be linked to the requested parent.
+func loadDiffLayer(parent snapshot, r *rlp.Stream) (snapshot, error) {
+	// Read the next diff journal entry
+	var (
+		number uint64
+		root   common.Hash
+	)
+	if err := r.Decode(&number); err != nil {
+		// The first read may fail with EOF, marking the end of the journal
+		if err == io.EOF {
+			return parent, nil
+		}
+		return nil, fmt.Errorf("load diff number: %v", err)
+	}
+	if err := r.Decode(&root); err != nil {
+		return nil, fmt.Errorf("load diff root: %v", err)
+	}
+	var accounts []journalAccount
+	if err := r.Decode(&accounts); err != nil {
+		return nil, fmt.Errorf("load diff accounts: %v", err)
+	}
+	accountData := make(map[common.Hash][]byte)
+	for _, entry := range accounts {
+		accountData[entry.Hash] = entry.Blob
+	}
+	var storage []journalStorage
+	if err := r.Decode(&storage); err != nil {
+		return nil, fmt.Errorf("load diff storage: %v", err)
+	}
+	storageData := make(map[common.Hash]map[common.Hash][]byte)
+	for _, entry := range storage {
+		slots := make(map[common.Hash][]byte)
+		for i, key := range entry.Keys {
+			slots[key] = entry.Vals[i]
+		}
+		storageData[entry.Hash] = slots
+	}
+	// Validate the block number to avoid state corruption
+	if parent, ok := parent.(*diffLayer); ok {
+		if number != parent.number+1 {
+			return nil, fmt.Errorf("snapshot chain broken: block #%d after #%d", number, parent.number)
+		}
+	}
+	return loadDiffLayer(newDiffLayer(parent, number, root, accountData, storageData), r)
+}
+
+// journal is the internal version of Journal that also returns the journal file
+// so subsequent layers know where to write to.
+func (dl *diffLayer) journal() (io.WriteCloser, error) {
+	// If we've reached the bottom, open the journal
+	var writer io.WriteCloser
+	if parent, ok := dl.parent.(*diskLayer); ok {
+		file, err := os.Create(parent.journal)
+		if err != nil {
+			return nil, err
+		}
+		writer = file
+	}
+	// If we haven't reached the bottom yet, journal the parent first
+	if writer == nil {
+		file, err := dl.parent.(*diffLayer).journal()
+		if err != nil {
+			return nil, err
+		}
+		writer = file
+	}
+	// Everything below was journalled, persist this layer too
+	if err := rlp.Encode(writer, dl.number); err != nil {
+		writer.Close()
+		return nil, err
+	}
+	if err := rlp.Encode(writer, dl.root); err != nil {
+		writer.Close()
+		return nil, err
+	}
+	accounts := make([]journalAccount, 0, len(dl.accountData))
+	for hash, blob := range dl.accountData {
+		accounts = append(accounts, journalAccount{Hash: hash, Blob: blob})
+	}
+	if err := rlp.Encode(writer, accounts); err != nil {
+		writer.Close()
+		return nil, err
+	}
+	storage := make([]journalStorage, 0, len(dl.storageData))
+	for hash, slots := range dl.storageData {
+		keys := make([]common.Hash, 0, len(slots))
+		vals := make([][]byte, 0, len(slots))
+		for key, val := range slots {
+			keys = append(keys, key)
+			vals = append(vals, val)
+		}
+		storage = append(storage, journalStorage{Hash: hash, Keys: keys, Vals: vals})
+	}
+	if err := rlp.Encode(writer, storage); err != nil {
+		writer.Close()
+		return nil, err
+	}
+	return writer, nil
+}

--- a/core/state/snapshot/difflayer_test.go
+++ b/core/state/snapshot/difflayer_test.go
@@ -194,7 +194,6 @@ func TestInsertAndMerge(t *testing.T) {
 
 // TestCapTree tests some functionality regarding capping/flattening
 func TestCapTree(t *testing.T) {
-
 	var (
 		storage = make(map[common.Hash]map[common.Hash][]byte)
 	)
@@ -204,20 +203,11 @@ func TestCapTree(t *testing.T) {
 		}
 	}
 	// the bottom-most layer, aside from the 'disk layer'
-	cache, _ := bigcache.NewBigCache(bigcache.Config{ // TODO(karalabe): dedup
-		Shards:             1,
-		LifeWindow:         time.Hour,
-		MaxEntriesInWindow: 1 * 1024,
-		MaxEntrySize:       1,
-		HardMaxCacheSize:   1,
-	})
-
+	cache, _ := bigcache.NewBigCache(bigcache.DefaultConfig(time.Minute))
 	base := &diskLayer{
-		journal: "",
-		db:      rawdb.NewMemoryDatabase(),
-		cache:   cache,
-		number:  0,
-		root:    common.HexToHash("0x01"),
+		db:    rawdb.NewMemoryDatabase(),
+		root:  common.HexToHash("0x01"),
+		cache: cache,
 	}
 	// The lowest difflayer
 	a1 := base.Update(common.HexToHash("0xa1"), setAccount("0xa1"), storage)
@@ -403,7 +393,6 @@ func BenchmarkSearchSlot(b *testing.B) {
 // Without sorting and tracking accountlist
 // BenchmarkFlatten-6   	     300	   5511511 ns/op
 func BenchmarkFlatten(b *testing.B) {
-
 	fill := func(parent snapshot, blocknum int) *diffLayer {
 		accounts := make(map[common.Hash][]byte)
 		storage := make(map[common.Hash]map[common.Hash][]byte)

--- a/core/state/snapshot/difflayer_test.go
+++ b/core/state/snapshot/difflayer_test.go
@@ -1,0 +1,147 @@
+package snapshot
+
+import (
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+func randomAccount() []byte {
+	root := randomHash()
+	a := Account{
+		Balance:  big.NewInt(rand.Int63()),
+		Nonce:    rand.Uint64(),
+		Root:     root[:],
+		CodeHash: emptyCode[:],
+	}
+	data, _ := rlp.EncodeToBytes(a)
+	return data
+}
+
+// TestMergeBasics tests some simple merges
+func TestMergeBasics(t *testing.T) {
+	var (
+		accounts = make(map[common.Hash][]byte)
+		storage  = make(map[common.Hash]map[common.Hash][]byte)
+	)
+	// Fill up a parent
+	for i := 0; i < 100; i++ {
+		h := randomHash()
+		data := randomAccount()
+
+		accounts[h] = data
+		if rand.Intn(20) < 10 {
+			accStorage := make(map[common.Hash][]byte)
+			value := make([]byte, 32)
+			rand.Read(value)
+			accStorage[randomHash()] = value
+			storage[h] = accStorage
+		}
+	}
+	// Add some (identical) layers on top
+	parent := newDiffLayer(nil, 1, common.Hash{}, accounts, storage)
+	child := newDiffLayer(parent, 1, common.Hash{}, accounts, storage)
+	child = newDiffLayer(child, 1, common.Hash{}, accounts, storage)
+	child = newDiffLayer(child, 1, common.Hash{}, accounts, storage)
+	child = newDiffLayer(child, 1, common.Hash{}, accounts, storage)
+	// And flatten
+	merged := (child.flatten()).(*diffLayer)
+	if got, exp := len(merged.accountList), len(accounts); got != exp {
+		t.Errorf("accountList wrong, got %v exp %v", got, exp)
+	}
+	if got, exp := len(merged.storageList), len(storage); got != exp {
+		t.Errorf("storageList wrong, got %v exp %v", got, exp)
+	}
+}
+
+// TestMergeDelete tests some deletion
+func TestMergeDelete(t *testing.T) {
+	var (
+		accountsA = make(map[common.Hash][]byte)
+		storage   = make(map[common.Hash]map[common.Hash][]byte)
+		accountsB = make(map[common.Hash][]byte)
+	)
+	// Fill up a parent
+	h1 := common.HexToHash("0x01")
+	h2 := common.HexToHash("0x02")
+
+	accountsA[h1] = randomAccount()
+	accountsA[h2] = nil
+
+	accountsB[h1] = nil
+	accountsB[h2] = randomAccount()
+
+	// Add some flip-flopping layers on top
+	parent := newDiffLayer(nil, 1, common.Hash{}, accountsA, storage)
+	child := newDiffLayer(parent, 2, common.Hash{}, accountsB, storage)
+	child = newDiffLayer(child, 3, common.Hash{}, accountsA, storage)
+	if child.Account(h1) == nil {
+		t.Errorf("last diff layer: expected %x to be non-nil", h1)
+	}
+	if child.Account(h2) != nil {
+		t.Errorf("last diff layer: expected %x to be nil", h2)
+	}
+	// And flatten
+	merged := (child.flatten()).(*diffLayer)
+	// These fails because the accounts-slice is reused, and not copied
+	// thus the flattening will affect the upper layers. Maybe that's totally
+	// fine, but if not, that needs to be taken care of
+	if merged.Account(h1) == nil {
+		t.Errorf("merged layer: expected %x to be non-nil", h1)
+	}
+	if merged.Account(h2) != nil {
+		t.Errorf("merged layer: expected %x to be nil", h2)
+	}
+}
+
+// TestMergeDelete2 tests some deletion
+func TestMergeDelete2(t *testing.T) {
+	var (
+		storage = make(map[common.Hash]map[common.Hash][]byte)
+	)
+	// Fill up a parent
+	h1 := common.HexToHash("0x01")
+	h2 := common.HexToHash("0x02")
+
+	flip := func() map[common.Hash][]byte {
+		accs := make(map[common.Hash][]byte)
+		accs[h1] = randomAccount()
+		accs[h2] = nil
+		return accs
+	}
+	flop := func() map[common.Hash][]byte {
+		accs := make(map[common.Hash][]byte)
+		accs[h1] = nil
+		accs[h2] = randomAccount()
+		return accs
+	}
+
+	// Add some flip-flopping layers on top
+	parent := newDiffLayer(nil, 1, common.Hash{}, flip(), storage)
+	child := newDiffLayer(parent, 2, common.Hash{}, flop(), storage)
+	child = newDiffLayer(child, 3, common.Hash{}, flip(), storage)
+	child = newDiffLayer(child, 3, common.Hash{}, flop(), storage)
+	child = newDiffLayer(child, 3, common.Hash{}, flip(), storage)
+	child = newDiffLayer(child, 3, common.Hash{}, flop(), storage)
+	child = newDiffLayer(child, 3, common.Hash{}, flip(), storage)
+	if child.Account(h1) == nil {
+		t.Errorf("last diff layer: expected %x to be non-nil", h1)
+	}
+	if child.Account(h2) != nil {
+		t.Errorf("last diff layer: expected %x to be nil", h2)
+	}
+	// And flatten
+	merged := (child.flatten()).(*diffLayer)
+	if merged.Account(h1) == nil {
+		t.Errorf("merged layer: expected %x to be non-nil", h1)
+	}
+	if merged.Account(h2) != nil {
+		t.Errorf("merged layer: expected %x to be nil", h2)
+	}
+	if got, exp := merged.memory, child.memory; got != exp {
+		t.Errorf("mem wrong, got %d, exp %d", got, exp)
+	}
+}

--- a/core/state/snapshot/difflayer_test.go
+++ b/core/state/snapshot/difflayer_test.go
@@ -18,15 +18,11 @@ package snapshot
 
 import (
 	"bytes"
-	"fmt"
 	"math/big"
 	"math/rand"
 	"testing"
-	"time"
 
-	"github.com/allegro/bigcache"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -192,100 +188,9 @@ func TestInsertAndMerge(t *testing.T) {
 	}
 }
 
-// TestCapTree tests some functionality regarding capping/flattening
-func TestCapTree(t *testing.T) {
-	var (
-		storage = make(map[common.Hash]map[common.Hash][]byte)
-	)
-	setAccount := func(accKey string) map[common.Hash][]byte {
-		return map[common.Hash][]byte{
-			common.HexToHash(accKey): randomAccount(),
-		}
-	}
-	// the bottom-most layer, aside from the 'disk layer'
-	cache, _ := bigcache.NewBigCache(bigcache.DefaultConfig(time.Minute))
-	base := &diskLayer{
-		db:    rawdb.NewMemoryDatabase(),
-		root:  common.HexToHash("0x01"),
-		cache: cache,
-	}
-	// The lowest difflayer
-	a1 := base.Update(common.HexToHash("0xa1"), setAccount("0xa1"), storage)
-
-	a2 := a1.Update(common.HexToHash("0xa2"), setAccount("0xa2"), storage)
-	b2 := a1.Update(common.HexToHash("0xb2"), setAccount("0xb2"), storage)
-
-	a3 := a2.Update(common.HexToHash("0xa3"), setAccount("0xa3"), storage)
-	b3 := b2.Update(common.HexToHash("0xb3"), setAccount("0xb3"), storage)
-
-	checkExist := func(layer *diffLayer, key string) error {
-		accountKey := common.HexToHash(key)
-		data, _ := layer.Account(accountKey)
-		if data == nil {
-			return fmt.Errorf("expected %x to exist, got nil", accountKey)
-		}
-		return nil
-	}
-	shouldErr := func(layer *diffLayer, key string) error {
-		accountKey := common.HexToHash(key)
-		data, err := layer.Account(accountKey)
-		if err == nil {
-			return fmt.Errorf("expected error, got data %x", data)
-		}
-		return nil
-	}
-
-	// check basics
-	if err := checkExist(b3, "0xa1"); err != nil {
-		t.Error(err)
-	}
-	if err := checkExist(b3, "0xb2"); err != nil {
-		t.Error(err)
-	}
-	if err := checkExist(b3, "0xb3"); err != nil {
-		t.Error(err)
-	}
-	// Now, merge the a-chain
-	diskNum, diffNum := a3.Cap(0, 1024)
-	if diskNum != 0 {
-		t.Errorf("disk layer err, got %d exp %d", diskNum, 0)
-	}
-	if diffNum != 2 {
-		t.Errorf("diff layer err, got %d exp %d", diffNum, 2)
-	}
-	// At this point, a2 got merged into a1. Thus, a1 is now modified,
-	// and as a1 is the parent of b2, b2 should no longer be able to iterate into parent
-
-	// These should still be accessible
-	if err := checkExist(b3, "0xb2"); err != nil {
-		t.Error(err)
-	}
-	if err := checkExist(b3, "0xb3"); err != nil {
-		t.Error(err)
-	}
-	//b2ParentNum, _ := b2.parent.Info()
-	//if b2.parent.invalid == false
-	//	t.Errorf("err, exp parent to be invalid, got %v", b2.parent, b2ParentNum)
-	//}
-	// But these would need iteration into the modified parent:
-	if err := shouldErr(b3, "0xa1"); err != nil {
-		t.Error(err)
-	}
-	if err := shouldErr(b3, "0xa2"); err != nil {
-		t.Error(err)
-	}
-	if err := shouldErr(b3, "0xa3"); err != nil {
-		t.Error(err)
-	}
-}
-
 type emptyLayer struct{}
 
 func (emptyLayer) Update(blockRoot common.Hash, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte) *diffLayer {
-	panic("implement me")
-}
-
-func (emptyLayer) Cap(layers int, memory uint64) (uint64, uint64) {
 	panic("implement me")
 }
 

--- a/core/state/snapshot/difflayer_test.go
+++ b/core/state/snapshot/difflayer_test.go
@@ -1,6 +1,23 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
 package snapshot
 
 import (
+	"bytes"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -49,56 +66,39 @@ func TestMergeBasics(t *testing.T) {
 	child = newDiffLayer(child, 1, common.Hash{}, accounts, storage)
 	// And flatten
 	merged := (child.flatten()).(*diffLayer)
-	if got, exp := len(merged.accountList), len(accounts); got != exp {
-		t.Errorf("accountList wrong, got %v exp %v", got, exp)
+
+	{ // Check account lists
+		// Should be zero/nil first
+		if got, exp := len(merged.accountList), 0; got != exp {
+			t.Errorf("accountList wrong, got %v exp %v", got, exp)
+		}
+		// Then set when we call AccountList
+		if got, exp := len(merged.AccountList()), len(accounts); got != exp {
+			t.Errorf("AccountList() wrong, got %v exp %v", got, exp)
+		}
+		if got, exp := len(merged.accountList), len(accounts); got != exp {
+			t.Errorf("accountList [2] wrong, got %v exp %v", got, exp)
+		}
 	}
-	if got, exp := len(merged.storageList), len(storage); got != exp {
-		t.Errorf("storageList wrong, got %v exp %v", got, exp)
+	{ // Check storage lists
+		i := 0
+		for aHash, sMap := range storage {
+			if got, exp := len(merged.storageList), i; got != exp {
+				t.Errorf("[1] storageList wrong, got %v exp %v", got, exp)
+			}
+			if got, exp := len(merged.StorageList(aHash)), len(sMap); got != exp {
+				t.Errorf("[2] StorageList() wrong, got %v exp %v", got, exp)
+			}
+			if got, exp := len(merged.storageList[aHash]), len(sMap); got != exp {
+				t.Errorf("storageList wrong, got %v exp %v", got, exp)
+			}
+			i++
+		}
 	}
 }
 
 // TestMergeDelete tests some deletion
 func TestMergeDelete(t *testing.T) {
-	var (
-		accountsA = make(map[common.Hash][]byte)
-		storage   = make(map[common.Hash]map[common.Hash][]byte)
-		accountsB = make(map[common.Hash][]byte)
-	)
-	// Fill up a parent
-	h1 := common.HexToHash("0x01")
-	h2 := common.HexToHash("0x02")
-
-	accountsA[h1] = randomAccount()
-	accountsA[h2] = nil
-
-	accountsB[h1] = nil
-	accountsB[h2] = randomAccount()
-
-	// Add some flip-flopping layers on top
-	parent := newDiffLayer(nil, 1, common.Hash{}, accountsA, storage)
-	child := newDiffLayer(parent, 2, common.Hash{}, accountsB, storage)
-	child = newDiffLayer(child, 3, common.Hash{}, accountsA, storage)
-	if child.Account(h1) == nil {
-		t.Errorf("last diff layer: expected %x to be non-nil", h1)
-	}
-	if child.Account(h2) != nil {
-		t.Errorf("last diff layer: expected %x to be nil", h2)
-	}
-	// And flatten
-	merged := (child.flatten()).(*diffLayer)
-	// These fails because the accounts-slice is reused, and not copied
-	// thus the flattening will affect the upper layers. Maybe that's totally
-	// fine, but if not, that needs to be taken care of
-	if merged.Account(h1) == nil {
-		t.Errorf("merged layer: expected %x to be non-nil", h1)
-	}
-	if merged.Account(h2) != nil {
-		t.Errorf("merged layer: expected %x to be nil", h2)
-	}
-}
-
-// TestMergeDelete2 tests some deletion
-func TestMergeDelete2(t *testing.T) {
 	var (
 		storage = make(map[common.Hash]map[common.Hash][]byte)
 	)
@@ -141,7 +141,197 @@ func TestMergeDelete2(t *testing.T) {
 	if merged.Account(h2) != nil {
 		t.Errorf("merged layer: expected %x to be nil", h2)
 	}
-	if got, exp := merged.memory, child.memory; got != exp {
-		t.Errorf("mem wrong, got %d, exp %d", got, exp)
+	// If we add more granular metering of memory, we can enable this again,
+	// but it's not implemented for now
+	//if got, exp := merged.memory, child.memory; got != exp {
+	//	t.Errorf("mem wrong, got %d, exp %d", got, exp)
+	//}
+}
+
+// This tests that if we create a new account, and set a slot, and then merge
+// it, the lists will be correct.
+func TestInsertAndMerge(t *testing.T) {
+	// Fill up a parent
+	var (
+		acc    = common.HexToHash("0x01")
+		slot   = common.HexToHash("0x02")
+		parent *diffLayer
+		child  *diffLayer
+	)
+	{
+		var accounts = make(map[common.Hash][]byte)
+		var storage = make(map[common.Hash]map[common.Hash][]byte)
+		parent = newDiffLayer(emptyLayer{}, 1, common.Hash{}, accounts, storage)
+	}
+	{
+		var accounts = make(map[common.Hash][]byte)
+		var storage = make(map[common.Hash]map[common.Hash][]byte)
+		accounts[acc] = randomAccount()
+		accstorage := make(map[common.Hash][]byte)
+		storage[acc] = accstorage
+		storage[acc][slot] = []byte{0x01}
+		child = newDiffLayer(parent, 2, common.Hash{}, accounts, storage)
+	}
+	// And flatten
+	merged := (child.flatten()).(*diffLayer)
+	{ // Check that slot value is present
+		if got, exp := merged.Storage(acc, slot), []byte{0x01}; bytes.Compare(got, exp) != 0 {
+			t.Errorf("merged slot value wrong, got %x, exp %x", got, exp)
+		}
+	}
+}
+
+type emptyLayer struct{}
+
+func (emptyLayer) Update(blockRoot common.Hash, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte) *diffLayer {
+	panic("implement me")
+}
+
+func (emptyLayer) Cap(layers int, memory uint64) (uint64, uint64) {
+	panic("implement me")
+}
+
+func (emptyLayer) Journal() error {
+	panic("implement me")
+}
+
+func (emptyLayer) Info() (uint64, common.Hash) {
+	panic("implement me")
+}
+
+func (emptyLayer) Account(hash common.Hash) *Account {
+	return nil
+}
+
+func (emptyLayer) AccountRLP(hash common.Hash) []byte {
+	return nil
+}
+
+func (emptyLayer) Storage(accountHash, storageHash common.Hash) []byte {
+	return nil
+}
+
+// BenchmarkSearch checks how long it takes to find a non-existing key
+// BenchmarkSearch-6   	  200000	     10481 ns/op (1K per layer)
+// BenchmarkSearch-6   	  200000	     10760 ns/op (10K per layer)
+// BenchmarkSearch-6   	  100000	     17866 ns/op
+//
+// BenchmarkSearch-6   	  500000	      3723 ns/op (10k per layer, only top-level RLock()
+func BenchmarkSearch(b *testing.B) {
+	// First, we set up 128 diff layers, with 1K items each
+
+	blocknum := uint64(0)
+	fill := func(parent snapshot) *diffLayer {
+		accounts := make(map[common.Hash][]byte)
+		storage := make(map[common.Hash]map[common.Hash][]byte)
+
+		for i := 0; i < 10000; i++ {
+			accounts[randomHash()] = randomAccount()
+		}
+		blocknum++
+		return newDiffLayer(parent, blocknum, common.Hash{}, accounts, storage)
+	}
+
+	var layer snapshot
+	layer = emptyLayer{}
+	for i := 0; i < 128; i++ {
+		layer = fill(layer)
+	}
+
+	key := common.Hash{}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		layer.AccountRLP(key)
+	}
+}
+
+// BenchmarkSearchSlot checks how long it takes to find a non-existing key
+// - Number of layers: 128
+// - Each layers contains the account, with a couple of storage slots
+// BenchmarkSearchSlot-6   	  100000	     14554 ns/op
+// BenchmarkSearchSlot-6   	  200000	      7158 ns/op (only top level RLock
+
+func BenchmarkSearchSlot(b *testing.B) {
+	// First, we set up 128 diff layers, with 1K items each
+
+	blocknum := uint64(0)
+	accountKey := common.Hash{}
+	storageKey := common.HexToHash("0x1337")
+	accountRLP := randomAccount()
+	fill := func(parent snapshot) *diffLayer {
+		accounts := make(map[common.Hash][]byte)
+		accounts[accountKey] = accountRLP
+		storage := make(map[common.Hash]map[common.Hash][]byte)
+
+		accStorage := make(map[common.Hash][]byte)
+		for i := 0; i < 5; i++ {
+			value := make([]byte, 32)
+			rand.Read(value)
+			accStorage[randomHash()] = value
+			storage[accountKey] = accStorage
+		}
+		blocknum++
+		return newDiffLayer(parent, blocknum, common.Hash{}, accounts, storage)
+	}
+
+	var layer snapshot
+	layer = emptyLayer{}
+	for i := 0; i < 128; i++ {
+		layer = fill(layer)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		layer.Storage(accountKey, storageKey)
+	}
+}
+
+// With accountList and sorting
+//BenchmarkFlatten-6   	      50	  29890856 ns/op
+//
+// Without sorting and tracking accountlist
+// BenchmarkFlatten-6   	     300	   5511511 ns/op
+func BenchmarkFlatten(b *testing.B) {
+
+	fill := func(parent snapshot, blocknum int) *diffLayer {
+		accounts := make(map[common.Hash][]byte)
+		storage := make(map[common.Hash]map[common.Hash][]byte)
+
+		for i := 0; i < 100; i++ {
+			accountKey := randomHash()
+			accounts[accountKey] = randomAccount()
+
+			accStorage := make(map[common.Hash][]byte)
+			for i := 0; i < 20; i++ {
+				value := make([]byte, 32)
+				rand.Read(value)
+				accStorage[randomHash()] = value
+
+			}
+			storage[accountKey] = accStorage
+		}
+		return newDiffLayer(parent, uint64(blocknum), common.Hash{}, accounts, storage)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		var layer snapshot
+		layer = emptyLayer{}
+		for i := 1; i < 128; i++ {
+			layer = fill(layer, i)
+		}
+		b.StartTimer()
+
+		for i := 1; i < 128; i++ {
+			dl, ok := layer.(*diffLayer)
+			if !ok {
+				break
+			}
+
+			layer = dl.flatten()
+		}
+		b.StopTimer()
 	}
 }

--- a/core/state/snapshot/disklayer.go
+++ b/core/state/snapshot/disklayer.go
@@ -126,12 +126,6 @@ func (dl *diskLayer) Update(blockHash common.Hash, accounts map[common.Hash][]by
 	return newDiffLayer(dl, dl.number+1, blockHash, accounts, storage)
 }
 
-// Cap traverses downwards the diff tree until the number of allowed layers are
-// crossed. All diffs beyond the permitted number are flattened downwards.
-func (dl *diskLayer) Cap(layers int, memory uint64) (uint64, uint64) {
-	return dl.number, dl.number
-}
-
 // Journal commits an entire diff hierarchy to disk into a single journal file.
 func (dl *diskLayer) Journal() error {
 	// There's no journalling a disk layer

--- a/core/state/snapshot/disklayer.go
+++ b/core/state/snapshot/disklayer.go
@@ -99,7 +99,7 @@ func (dl *diskLayer) Storage(accountHash, storageHash common.Hash) []byte {
 // the specified data items. Note, the maps are retained by the method to avoid
 // copying everything.
 func (dl *diskLayer) Update(blockHash common.Hash, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte) *diffLayer {
-	return newDiffLayer(dl, blockHash, accounts, storage)
+	return newDiffLayer(dl, dl.number+1, blockHash, accounts, storage)
 }
 
 // Cap traverses downwards the diff tree until the number of allowed layers are

--- a/core/state/snapshot/disklayer.go
+++ b/core/state/snapshot/disklayer.go
@@ -1,0 +1,115 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshot
+
+import (
+	"github.com/allegro/bigcache"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// diskLayer is a low level persistent snapshot built on top of a key-value store.
+type diskLayer struct {
+	journal string              // Path of the snapshot journal to use on shutdown
+	db      ethdb.KeyValueStore // Key-value store containing the base snapshot
+	cache   *bigcache.BigCache  // Cache to avoid hitting the disk for direct access
+
+	number uint64      // Block number of the base snapshot
+	root   common.Hash // Root hash of the base snapshot
+}
+
+// Info returns the block number and root hash for which this snapshot was made.
+func (dl *diskLayer) Info() (uint64, common.Hash) {
+	return dl.number, dl.root
+}
+
+// Account directly retrieves the account associated with a particular hash in
+// the snapshot slim data format.
+func (dl *diskLayer) Account(hash common.Hash) *Account {
+	data := dl.AccountRLP(hash)
+	if len(data) == 0 { // can be both nil and []byte{}
+		return nil
+	}
+	account := new(Account)
+	if err := rlp.DecodeBytes(data, account); err != nil {
+		panic(err)
+	}
+	return account
+}
+
+// AccountRLP directly retrieves the account RLP associated with a particular
+// hash in the snapshot slim data format.
+func (dl *diskLayer) AccountRLP(hash common.Hash) []byte {
+	key := string(hash[:])
+
+	// Try to retrieve the account from the memory cache
+	if blob, err := dl.cache.Get(key); err == nil {
+		snapshotCleanHitMeter.Mark(1)
+		snapshotCleanReadMeter.Mark(int64(len(blob)))
+		return blob
+	}
+	// Cache doesn't contain account, pull from disk and cache for later
+	blob := rawdb.ReadAccountSnapshot(dl.db, hash)
+	dl.cache.Set(key, blob)
+
+	snapshotCleanMissMeter.Mark(1)
+	snapshotCleanWriteMeter.Mark(int64(len(blob)))
+
+	return blob
+}
+
+// Storage directly retrieves the storage data associated with a particular hash,
+// within a particular account.
+func (dl *diskLayer) Storage(accountHash, storageHash common.Hash) []byte {
+	key := string(append(accountHash[:], storageHash[:]...))
+
+	// Try to retrieve the storage slot from the memory cache
+	if blob, err := dl.cache.Get(key); err == nil {
+		snapshotCleanHitMeter.Mark(1)
+		snapshotCleanReadMeter.Mark(int64(len(blob)))
+		return blob
+	}
+	// Cache doesn't contain storage slot, pull from disk and cache for later
+	blob := rawdb.ReadStorageSnapshot(dl.db, accountHash, storageHash)
+	dl.cache.Set(key, blob)
+
+	snapshotCleanMissMeter.Mark(1)
+	snapshotCleanWriteMeter.Mark(int64(len(blob)))
+
+	return blob
+}
+
+// Update creates a new layer on top of the existing snapshot diff tree with
+// the specified data items. Note, the maps are retained by the method to avoid
+// copying everything.
+func (dl *diskLayer) Update(blockHash common.Hash, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte) *diffLayer {
+	return newDiffLayer(dl, blockHash, accounts, storage)
+}
+
+// Cap traverses downwards the diff tree until the number of allowed layers are
+// crossed. All diffs beyond the permitted number are flattened downwards.
+func (dl *diskLayer) Cap(layers int, memory uint64) (uint64, uint64) {
+	return dl.number, dl.number
+}
+
+// Journal commits an entire diff hierarchy to disk into a single journal file.
+func (dl *diskLayer) Journal() error {
+	// There's no journalling a disk layer
+	return nil
+}

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -135,6 +135,7 @@ func generateSnapshot(db ethdb.KeyValueStore, journal string, headNumber uint64,
 			curStorageNodes int
 			curAccountSize  common.StorageSize
 			curStorageSize  common.StorageSize
+			accountHash     = common.BytesToHash(accIt.Key)
 		)
 		var acc struct {
 			Nonce    uint64
@@ -148,7 +149,7 @@ func generateSnapshot(db ethdb.KeyValueStore, journal string, headNumber uint64,
 		data := AccountRLP(acc.Nonce, acc.Balance, acc.Root, acc.CodeHash)
 		curAccountSize += common.StorageSize(1 + common.HashLength + len(data))
 
-		rawdb.WriteAccountSnapshot(batch, common.BytesToHash(accIt.Key), data)
+		rawdb.WriteAccountSnapshot(batch, accountHash, data)
 		if batch.ValueSize() > ethdb.IdealBatchSize {
 			batch.Write()
 			batch.Reset()
@@ -163,7 +164,7 @@ func generateSnapshot(db ethdb.KeyValueStore, journal string, headNumber uint64,
 				curStorageSize += common.StorageSize(1 + 2*common.HashLength + len(storeIt.Value))
 				curStorageCount++
 
-				rawdb.WriteStorageSnapshot(batch, common.BytesToHash(accIt.Key), common.BytesToHash(storeIt.Key), storeIt.Value)
+				rawdb.WriteStorageSnapshot(batch, accountHash, common.BytesToHash(storeIt.Key), storeIt.Value)
 				if batch.ValueSize() > ethdb.IdealBatchSize {
 					batch.Write()
 					batch.Reset()

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -1,0 +1,206 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshot
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/allegro/bigcache"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/trie"
+)
+
+var (
+	// emptyRoot is the known root hash of an empty trie.
+	emptyRoot = common.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+
+	// emptyCode is the known hash of the empty EVM bytecode.
+	emptyCode = crypto.Keccak256Hash(nil)
+)
+
+// wipeSnapshot iterates over the entire key-value database and deletes all the
+// data associated with the snapshot (accounts, storage, metadata). After all is
+// done, the snapshot range of the database is compacted to free up unused data
+// blocks.
+func wipeSnapshot(db ethdb.KeyValueStore) error {
+	// Batch deletions together to avoid holding an iterator for too long
+	var (
+		batch = db.NewBatch()
+		items int
+	)
+	// Iterate over the snapshot key-range and delete all of them
+	log.Info("Deleting previous snapshot leftovers")
+	start, logged := time.Now(), time.Now()
+
+	it := db.NewIteratorWithStart(rawdb.StateSnapshotPrefix)
+	for it.Next() {
+		// Skip any keys with the correct prefix but wrong lenth (trie nodes)
+		key := it.Key()
+		if !bytes.HasPrefix(key, rawdb.StateSnapshotPrefix) {
+			break
+		}
+		if len(key) != len(rawdb.StateSnapshotPrefix)+common.HashLength && len(key) != len(rawdb.StateSnapshotPrefix)+2*common.HashLength {
+			continue
+		}
+		// Delete the key and periodically recreate the batch and iterator
+		batch.Delete(key)
+		items++
+
+		if items%10000 == 0 {
+			// Batch too large (or iterator too long lived, flush and recreate)
+			it.Release()
+			if err := batch.Write(); err != nil {
+				return err
+			}
+			batch.Reset()
+			it = db.NewIteratorWithStart(key)
+
+			if time.Since(logged) > 8*time.Second {
+				log.Info("Deleting previous snapshot leftovers", "wiped", items, "elapsed", time.Since(start))
+				logged = time.Now()
+			}
+		}
+	}
+	it.Release()
+
+	rawdb.DeleteSnapshotBlock(batch)
+	if err := batch.Write(); err != nil {
+		return err
+	}
+	log.Info("Deleted previous snapshot leftovers", "wiped", items, "elapsed", time.Since(start))
+
+	// Compact the snapshot section of the database to get rid of unused space
+	log.Info("Compacting snapshot area in database")
+	start = time.Now()
+
+	end := common.CopyBytes(rawdb.StateSnapshotPrefix)
+	end[len(end)-1]++
+
+	if err := db.Compact(rawdb.StateSnapshotPrefix, end); err != nil {
+		return err
+	}
+	log.Info("Compacted snapshot area in database", "elapsed", time.Since(start))
+
+	return nil
+}
+
+// generateSnapshot regenerates a brand new snapshot based on an existing state database and head block.
+func generateSnapshot(db ethdb.KeyValueStore, journal string, headNumber uint64, headRoot common.Hash) (snapshot, error) {
+	// Wipe any previously existing snapshot from the database
+	if err := wipeSnapshot(db); err != nil {
+		return nil, err
+	}
+	// Iterate the entire storage trie and re-generate the state snapshot
+	var (
+		accountCount int
+		storageCount int
+		storageNodes int
+		accountSize  common.StorageSize
+		storageSize  common.StorageSize
+	)
+	batch := db.NewBatch()
+	triedb := trie.NewDatabase(db)
+
+	accTrie, err := trie.NewSecure(headRoot, triedb)
+	if err != nil {
+		return nil, err
+	}
+	accIt := trie.NewIterator(accTrie.NodeIterator(nil))
+	for accIt.Next() {
+		var (
+			curStorageCount int
+			curStorageNodes int
+			curAccountSize  common.StorageSize
+			curStorageSize  common.StorageSize
+		)
+		var acc struct {
+			Nonce    uint64
+			Balance  *big.Int
+			Root     common.Hash
+			CodeHash []byte
+		}
+		if err := rlp.DecodeBytes(accIt.Value, &acc); err != nil {
+			return nil, err
+		}
+		data := AccountRLP(acc.Nonce, acc.Balance, acc.Root, acc.CodeHash)
+		curAccountSize += common.StorageSize(1 + common.HashLength + len(data))
+
+		rawdb.WriteAccountSnapshot(batch, common.BytesToHash(accIt.Key), data)
+		if batch.ValueSize() > ethdb.IdealBatchSize {
+			batch.Write()
+			batch.Reset()
+		}
+		if acc.Root != emptyRoot {
+			storeTrie, err := trie.NewSecure(acc.Root, triedb)
+			if err != nil {
+				return nil, err
+			}
+			storeIt := trie.NewIterator(storeTrie.NodeIterator(nil))
+			for storeIt.Next() {
+				curStorageSize += common.StorageSize(1 + 2*common.HashLength + len(storeIt.Value))
+				curStorageCount++
+
+				rawdb.WriteStorageSnapshot(batch, common.BytesToHash(accIt.Key), common.BytesToHash(storeIt.Key), storeIt.Value)
+				if batch.ValueSize() > ethdb.IdealBatchSize {
+					batch.Write()
+					batch.Reset()
+				}
+			}
+			curStorageNodes = storeIt.Nodes
+		}
+		accountCount++
+		storageCount += curStorageCount
+		accountSize += curAccountSize
+		storageSize += curStorageSize
+		storageNodes += curStorageNodes
+
+		fmt.Printf("%#x: %9s + %9s (%6d slots, %6d nodes), total %9s (%d accs, %d nodes) + %9s (%d slots, %d nodes)\n", accIt.Key, curAccountSize.TerminalString(), curStorageSize.TerminalString(), curStorageCount, curStorageNodes, accountSize.TerminalString(), accountCount, accIt.Nodes, storageSize.TerminalString(), storageCount, storageNodes)
+	}
+	// Update the snapshot block marker and write any remainder data
+	rawdb.WriteSnapshotBlock(batch, headNumber, headRoot)
+	batch.Write()
+	batch.Reset()
+
+	// Compact the snapshot section of the database to get rid of unused space
+	log.Info("Compacting snapshot in chain database")
+	if err := db.Compact([]byte{'s'}, []byte{'s' + 1}); err != nil {
+		return nil, err
+	}
+	// New snapshot generated, construct a brand new base layer
+	cache, _ := bigcache.NewBigCache(bigcache.Config{ // TODO(karalabe): dedup
+		Shards:             1024,
+		LifeWindow:         time.Hour,
+		MaxEntriesInWindow: 512 * 1024,
+		MaxEntrySize:       512,
+		HardMaxCacheSize:   512,
+	})
+	return &diskLayer{
+		journal: journal,
+		db:      db,
+		cache:   cache,
+		number:  headNumber,
+		root:    headRoot,
+	}, nil
+}

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -1,0 +1,111 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshot
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/ethdb/memorydb"
+)
+
+// randomHash generates a random blob of data and returns it as a hash.
+func randomHash() common.Hash {
+	var hash common.Hash
+	if n, err := rand.Read(hash[:]); n != common.HashLength || err != nil {
+		panic(err)
+	}
+	return hash
+}
+
+// Tests that given a database with random data content, all parts of a snapshot
+// can be crrectly wiped without touching anything else.
+func TestWipe(t *testing.T) {
+	// Create a database with some random snapshot data
+	db := memorydb.New()
+
+	for i := 0; i < 128; i++ {
+		account := randomHash()
+		rawdb.WriteAccountSnapshot(db, account, randomHash().Bytes())
+		for j := 0; j < 1024; j++ {
+			rawdb.WriteStorageSnapshot(db, account, randomHash(), randomHash().Bytes())
+		}
+	}
+	rawdb.WriteSnapshotBlock(db, 123, randomHash())
+
+	// Add some random non-snapshot data too to make wiping harder
+	for i := 0; i < 65536; i++ {
+		// Generate a key that's the wrong length for a state snapshot item
+		var keysize int
+		for keysize == 0 || keysize == 32 || keysize == 64 {
+			keysize = 8 + rand.Intn(64) // +8 to ensure we will "never" randomize duplicates
+		}
+		// Randomize the suffix, dedup and inject it under the snapshot namespace
+		keysuffix := make([]byte, keysize)
+		rand.Read(keysuffix)
+		db.Put(append(rawdb.StateSnapshotPrefix, keysuffix...), randomHash().Bytes())
+	}
+	// Sanity check that all the keys are present
+	var items int
+
+	it := db.NewIteratorWithPrefix(rawdb.StateSnapshotPrefix)
+	defer it.Release()
+
+	for it.Next() {
+		key := it.Key()
+		if len(key) == len(rawdb.StateSnapshotPrefix)+32 || len(key) == len(rawdb.StateSnapshotPrefix)+64 {
+			items++
+		}
+	}
+	if items != 128+128*1024 {
+		t.Fatalf("snapshot size mismatch: have %d, want %d", items, 128+128*1024)
+	}
+	if number, hash := rawdb.ReadSnapshotBlock(db); number != 123 || hash == (common.Hash{}) {
+		t.Errorf("snapshot block marker mismatch: have #%d [%#x], want #%d [<not-nil>]", number, hash, 123)
+	}
+	// Wipe all snapshot entries from the database
+	if err := wipeSnapshot(db); err != nil {
+		t.Fatalf("failed to wipe snapshot: %v", err)
+	}
+	// Iterate over the database end ensure no snapshot information remains
+	it = db.NewIteratorWithPrefix(rawdb.StateSnapshotPrefix)
+	defer it.Release()
+
+	for it.Next() {
+		key := it.Key()
+		if len(key) == len(rawdb.StateSnapshotPrefix)+32 || len(key) == len(rawdb.StateSnapshotPrefix)+64 {
+			t.Errorf("snapshot entry remained after wipe: %x", key)
+		}
+	}
+	if number, hash := rawdb.ReadSnapshotBlock(db); number != 0 || hash != (common.Hash{}) {
+		t.Errorf("snapshot block marker remained after wipe: #%d [%#x]", number, hash)
+	}
+	// Iterate over the database and ensure miscellaneous items are present
+	items = 0
+
+	it = db.NewIterator()
+	defer it.Release()
+
+	for it.Next() {
+		items++
+	}
+	if items != 65536 {
+		t.Fatalf("misc item count mismatch: have %d, want %d", items, 65536)
+	}
+}

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -38,6 +38,11 @@ var (
 	snapshotCleanMissMeter  = metrics.NewRegisteredMeter("state/snapshot/clean/miss", nil)
 	snapshotCleanReadMeter  = metrics.NewRegisteredMeter("state/snapshot/clean/read", nil)
 	snapshotCleanWriteMeter = metrics.NewRegisteredMeter("state/snapshot/clean/write", nil)
+
+	// ErrSnapshotStale is returned from data accessors if the underlying snapshot
+	// layer had been invalidated due to the chain progressing forward far enough
+	// to not maintain the layer's original state.
+	ErrSnapshotStale = errors.New("snapshot stale")
 )
 
 // Snapshot represents the functionality supported by a snapshot storage layer.
@@ -47,15 +52,15 @@ type Snapshot interface {
 
 	// Account directly retrieves the account associated with a particular hash in
 	// the snapshot slim data format.
-	Account(hash common.Hash) *Account
+	Account(hash common.Hash) (*Account, error)
 
 	// AccountRLP directly retrieves the account RLP associated with a particular
 	// hash in the snapshot slim data format.
-	AccountRLP(hash common.Hash) []byte
+	AccountRLP(hash common.Hash) ([]byte, error)
 
 	// Storage directly retrieves the storage data associated with a particular hash,
 	// within a particular account.
-	Storage(accountHash, storageHash common.Hash) []byte
+	Storage(accountHash, storageHash common.Hash) ([]byte, error)
 }
 
 // snapshot is the internal version of the snapshot data layer that supports some

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -80,7 +80,7 @@ type snapshot interface {
 }
 
 // SnapshotTree is an Ethereum state snapshot tree. It consists of one persistent
-// base layer backed by a key-value store, on top of which arbitrarilly many in-
+// base layer backed by a key-value store, on top of which arbitrarily many in-
 // memory diff layers are topped. The memory diffs can form a tree with branching,
 // but the disk layer is singleton and common to all. If a reorg goes deeper than
 // the disk layer, everything needs to be deleted.
@@ -220,7 +220,7 @@ func loadSnapshot(db ethdb.KeyValueStore, journal string, headNumber uint64, hea
 	if _, err := os.Stat(journal); os.IsNotExist(err) {
 		// Journal doesn't exist, don't worry if it's not supposed to
 		if number != headNumber || root != headRoot {
-			return nil, fmt.Errorf("snapshot journal missing, head does't match snapshot: #%d [%#x] vs. #%d [%#x]",
+			return nil, fmt.Errorf("snapshot journal missing, head doesn't match snapshot: #%d [%#x] vs. #%d [%#x]",
 				headNumber, headRoot, number, root)
 		}
 		return base, nil
@@ -237,7 +237,7 @@ func loadSnapshot(db ethdb.KeyValueStore, journal string, headNumber uint64, hea
 	// Journal doesn't exist, don't worry if it's not supposed to
 	number, root = snapshot.Info()
 	if number != headNumber || root != headRoot {
-		return nil, fmt.Errorf("head does't match snapshot: #%d [%#x] vs. #%d [%#x]",
+		return nil, fmt.Errorf("head doesn't match snapshot: #%d [%#x] vs. #%d [%#x]",
 			headNumber, headRoot, number, root)
 	}
 	return snapshot, nil

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -1,0 +1,243 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package snapshot implements a journalled, dynamic state dump.
+package snapshot
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/allegro/bigcache"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
+)
+
+var (
+	snapshotCleanHitMeter   = metrics.NewRegisteredMeter("state/snapshot/clean/hit", nil)
+	snapshotCleanMissMeter  = metrics.NewRegisteredMeter("state/snapshot/clean/miss", nil)
+	snapshotCleanReadMeter  = metrics.NewRegisteredMeter("state/snapshot/clean/read", nil)
+	snapshotCleanWriteMeter = metrics.NewRegisteredMeter("state/snapshot/clean/write", nil)
+)
+
+// Snapshot represents the functionality supported by a snapshot storage layer.
+type Snapshot interface {
+	// Info returns the block number and root hash for which this snapshot was made.
+	Info() (uint64, common.Hash)
+
+	// Account directly retrieves the account associated with a particular hash in
+	// the snapshot slim data format.
+	Account(hash common.Hash) *Account
+
+	// AccountRLP directly retrieves the account RLP associated with a particular
+	// hash in the snapshot slim data format.
+	AccountRLP(hash common.Hash) []byte
+
+	// Storage directly retrieves the storage data associated with a particular hash,
+	// within a particular account.
+	Storage(accountHash, storageHash common.Hash) []byte
+}
+
+// snapshot is the internal version of the snapshot data layer that supports some
+// additional methods compared to the public API.
+type snapshot interface {
+	Snapshot
+
+	// Update creates a new layer on top of the existing snapshot diff tree with
+	// the specified data items. Note, the maps are retained by the method to avoid
+	// copying everything.
+	Update(blockRoot common.Hash, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte) *diffLayer
+
+	// Cap traverses downwards the diff tree until the number of allowed layers are
+	// crossed. All diffs beyond the permitted number are flattened downwards. The
+	// block numbers for the disk layer and first diff layer are returned for GC.
+	Cap(layers int, memory uint64) (uint64, uint64)
+
+	// Journal commits an entire diff hierarchy to disk into a single journal file.
+	// This is meant to be used during shutdown to persist the snapshot without
+	// flattening everything down (bad for reorgs).
+	Journal() error
+}
+
+// SnapshotTree is an Ethereum state snapshot tree. It consists of one persistent
+// base layer backed by a key-value store, on top of which arbitrarilly many in-
+// memory diff layers are topped. The memory diffs can form a tree with branching,
+// but the disk layer is singleton and common to all. If a reorg goes deeper than
+// the disk layer, everything needs to be deleted.
+//
+// The goal of a state snapshot is twofold: to allow direct access to account and
+// storage data to avoid expensive multi-level trie lookups; and to allow sorted,
+// cheap iteration of the account/storage tries for sync aid.
+type SnapshotTree struct {
+	layers map[common.Hash]snapshot // Collection of all known layers
+	lock   sync.RWMutex
+}
+
+// New attempts to load an already existing snapshot from a persistent key-value
+// store (with a number of memory layers from a journal), ensuring that the head
+// of the snapshot matches the expected one.
+//
+// If the snapshot is missing or inconsistent, the entirety is deleted and will
+// be reconstructed from scratch based on the tries in the key-value store.
+func New(db ethdb.KeyValueStore, journal string, headNumber uint64, headRoot common.Hash) (*SnapshotTree, error) {
+	// Attempt to load a previously persisted snapshot
+	head, err := loadSnapshot(db, journal, headNumber, headRoot)
+	if err != nil {
+		log.Warn("Failed to load snapshot, regenerating", "err", err)
+		if head, err = generateSnapshot(db, journal, headNumber, headRoot); err != nil {
+			return nil, err
+		}
+	}
+	// Existing snapshot loaded or one regenerated, seed all the layers
+	snap := &SnapshotTree{
+		layers: make(map[common.Hash]snapshot),
+	}
+	for head != nil {
+		_, root := head.Info()
+		snap.layers[root] = head
+
+		switch self := head.(type) {
+		case *diffLayer:
+			head = self.parent
+		case *diskLayer:
+			head = nil
+		default:
+			panic(fmt.Sprintf("unknown data layer: %T", self))
+		}
+	}
+	return snap, nil
+}
+
+// Snapshot retrieves a snapshot belonging to the given block root, or nil if no
+// snapshot is maintained for that block.
+func (st *SnapshotTree) Snapshot(blockRoot common.Hash) Snapshot {
+	st.lock.RLock()
+	defer st.lock.RUnlock()
+
+	return st.layers[blockRoot]
+}
+
+// Update adds a new snapshot into the tree, if that can be linked to an existing
+// old parent. It is disallowed to insert a disk layer (the origin of all).
+func (st *SnapshotTree) Update(blockRoot common.Hash, parentRoot common.Hash, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte) error {
+	// Generate a new snapshot on top of the parent
+	parent := st.Snapshot(parentRoot).(snapshot)
+	if parent == nil {
+		return fmt.Errorf("parent [%#x] snapshot missing", parentRoot)
+	}
+	snap := parent.Update(blockRoot, accounts, storage)
+
+	// Save the new snapshot for later
+	st.lock.Lock()
+	defer st.lock.Unlock()
+
+	st.layers[snap.root] = snap
+	return nil
+}
+
+// Cap traverses downwards the snapshot tree from a head block hash until the
+// number of allowed layers are crossed. All layers beyond the permitted number
+// are flattened downwards.
+func (st *SnapshotTree) Cap(blockRoot common.Hash, layers int, memory uint64) error {
+	// Retrieve the head snapshot to cap from
+	snap := st.Snapshot(blockRoot).(snapshot)
+	if snap == nil {
+		return fmt.Errorf("snapshot [%#x] missing", blockRoot)
+	}
+	// Run the internal capping and discard all stale layers
+	st.lock.Lock()
+	defer st.lock.Unlock()
+
+	diskNumber, diffNumber := snap.Cap(layers, memory)
+	for root, snap := range st.layers {
+		if number, _ := snap.Info(); number != diskNumber && number < diffNumber {
+			delete(st.layers, root)
+		}
+	}
+	return nil
+}
+
+// Journal commits an entire diff hierarchy to disk into a single journal file.
+// This is meant to be used during shutdown to persist the snapshot without
+// flattening everything down (bad for reorgs).
+func (st *SnapshotTree) Journal(blockRoot common.Hash) error {
+	// Retrieve the head snapshot to journal from
+	snap := st.Snapshot(blockRoot).(snapshot)
+	if snap == nil {
+		return fmt.Errorf("snapshot [%#x] missing", blockRoot)
+	}
+	// Run the journaling
+	st.lock.Lock()
+	defer st.lock.Unlock()
+
+	return snap.Journal()
+}
+
+// loadSnapshot loads a pre-existing state snapshot backed by a key-value store.
+func loadSnapshot(db ethdb.KeyValueStore, journal string, headNumber uint64, headRoot common.Hash) (snapshot, error) {
+	// Retrieve the block number and hash of the snapshot, failing if no snapshot
+	// is present in the database (or crashed mid-update).
+	number, root := rawdb.ReadSnapshotBlock(db)
+	if root == (common.Hash{}) {
+		return nil, errors.New("missing or corrupted snapshot")
+	}
+	cache, _ := bigcache.NewBigCache(bigcache.Config{ // TODO(karalabe): dedup
+		Shards:             1024,
+		LifeWindow:         time.Hour,
+		MaxEntriesInWindow: 512 * 1024,
+		MaxEntrySize:       512,
+		HardMaxCacheSize:   512,
+	})
+	base := &diskLayer{
+		journal: journal,
+		db:      db,
+		cache:   cache,
+		number:  number,
+		root:    root,
+	}
+	// Load all the snapshot diffs from the journal, failing if their chain is broken
+	// or does not lead from the disk snapshot to the specified head.
+	if _, err := os.Stat(journal); os.IsNotExist(err) {
+		// Journal doesn't exist, don't worry if it's not supposed to
+		if number != headNumber || root != headRoot {
+			return nil, fmt.Errorf("snapshot journal missing, head does't match snapshot: #%d [%#x] vs. #%d [%#x]",
+				headNumber, headRoot, number, root)
+		}
+		return base, nil
+	}
+	file, err := os.Open(journal)
+	if err != nil {
+		return nil, err
+	}
+	snapshot, err := loadDiffLayer(base, file)
+	if err != nil {
+		return nil, err
+	}
+	// Entire snapshot journal loaded, sanity check the head and return
+	// Journal doesn't exist, don't worry if it's not supposed to
+	number, root = snapshot.Info()
+	if number != headNumber || root != headRoot {
+		return nil, fmt.Errorf("head does't match snapshot: #%d [%#x] vs. #%d [%#x]",
+			headNumber, headRoot, number, root)
+	}
+	return snapshot, nil
+}

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -160,13 +160,15 @@ func (st *SnapshotTree) Update(blockRoot common.Hash, parentRoot common.Hash, ac
 // are flattened downwards.
 func (st *SnapshotTree) Cap(blockRoot common.Hash, layers int, memory uint64) error {
 	// Retrieve the head snapshot to cap from
-	snap := st.Snapshot(blockRoot).(snapshot)
-	if snap == nil {
+	var snap snapshot
+	if s := st.Snapshot(blockRoot); s == nil {
 		return fmt.Errorf("snapshot [%#x] missing", blockRoot)
+	} else {
+		snap = s.(snapshot)
 	}
 	diff, ok := snap.(*diffLayer)
 	if !ok {
-		return fmt.Errorf("snapshot [%#x] is base layer", blockRoot)
+		return fmt.Errorf("snapshot [%#x] is disk layer", blockRoot)
 	}
 	// Run the internal capping and discard all stale layers
 	st.lock.Lock()
@@ -356,9 +358,11 @@ func diffToDisk(bottom *diffLayer) *diskLayer {
 // flattening everything down (bad for reorgs).
 func (st *SnapshotTree) Journal(blockRoot common.Hash) error {
 	// Retrieve the head snapshot to journal from
-	snap := st.Snapshot(blockRoot).(snapshot)
-	if snap == nil {
+	var snap snapshot
+	if s := st.Snapshot(blockRoot); s == nil {
 		return fmt.Errorf("snapshot [%#x] missing", blockRoot)
+	} else {
+		snap = s.(snapshot)
 	}
 	// Run the journaling
 	st.lock.Lock()

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 var (
@@ -88,7 +89,7 @@ type snapshot interface {
 // storage data to avoid expensive multi-level trie lookups; and to allow sorted,
 // cheap iteration of the account/storage tries for sync aid.
 type SnapshotTree struct {
-	layers map[common.Hash]snapshot // Collection of all known layers
+	layers map[common.Hash]snapshot // Collection of all known layers // TODO(karalabe): split Clique overlaps
 	lock   sync.RWMutex
 }
 
@@ -228,7 +229,7 @@ func loadSnapshot(db ethdb.KeyValueStore, journal string, headNumber uint64, hea
 	if err != nil {
 		return nil, err
 	}
-	snapshot, err := loadDiffLayer(base, file)
+	snapshot, err := loadDiffLayer(base, rlp.NewStream(file, 0))
 	if err != nil {
 		return nil, err
 	}

--- a/core/state/snapshot/snapshot_test.go
+++ b/core/state/snapshot/snapshot_test.go
@@ -1,0 +1,17 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshot

--- a/core/state/snapshot/snapshot_test.go
+++ b/core/state/snapshot/snapshot_test.go
@@ -313,4 +313,9 @@ func TestPostCapBasicDataAccess(t *testing.T) {
 	if err := shouldErr(snap, "0xa3"); err != nil {
 		t.Error(err)
 	}
+	// Now, merge it again, just for fun. It should now error, since a3
+	// is a disk layer
+	if err := snaps.Cap(common.HexToHash("0xa3"), 0, 1024); err == nil {
+		t.Error("expected error capping the disk layer, got none")
+	}
 }

--- a/core/state/snapshot/snapshot_test.go
+++ b/core/state/snapshot/snapshot_test.go
@@ -205,6 +205,15 @@ func TestDiffLayerExternalInvalidationPartialFlatten(t *testing.T) {
 	}
 	ref := snaps.Snapshot(common.HexToHash("0x02"))
 
+	// Doing a Cap operation with many allowed layers should be a no-op
+	exp := len(snaps.layers)
+	if err := snaps.Cap(common.HexToHash("0x04"), 2000, 1024*1024); err != nil {
+		t.Fatalf("failed to flatten diff layer into accumulator: %v", err)
+	}
+	if got := len(snaps.layers); got != exp {
+		t.Errorf("layers modified, got %d exp %d", got, exp)
+	}
+
 	// Flatten the diff layer into the bottom accumulator
 	if err := snaps.Cap(common.HexToHash("0x04"), 2, 1024*1024); err != nil {
 		t.Fatalf("failed to flatten diff layer into accumulator: %v", err)

--- a/core/state/snapshot/snapshot_test.go
+++ b/core/state/snapshot/snapshot_test.go
@@ -17,6 +17,7 @@
 package snapshot
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -51,8 +52,11 @@ func TestDiskLayerExternalInvalidationFullFlatten(t *testing.T) {
 	if err := snaps.Update(common.HexToHash("0x02"), common.HexToHash("0x01"), accounts, storage); err != nil {
 		t.Fatalf("failed to create a diff layer: %v", err)
 	}
+	if n := len(snaps.layers); n != 2 {
+		t.Errorf("pre-cap layer count mismatch: have %d, want %d", n, 2)
+	}
 	// Commit the diff layer onto the disk and ensure it's persisted
-	if err := snaps.Cap(common.HexToHash("0x02"), 1, 0); err != nil {
+	if err := snaps.Cap(common.HexToHash("0x02"), 0, 0); err != nil {
 		t.Fatalf("failed to merge diff layer onto disk: %v", err)
 	}
 	// Since the base layer was modified, ensure that data retrievald on the external reference fail
@@ -61,6 +65,10 @@ func TestDiskLayerExternalInvalidationFullFlatten(t *testing.T) {
 	}
 	if slot, err := ref.Storage(common.HexToHash("0xa1"), common.HexToHash("0xb1")); err != ErrSnapshotStale {
 		t.Errorf("stale reference returned storage slot: %#x (err: %v)", slot, err)
+	}
+	if n := len(snaps.layers); n != 1 {
+		t.Errorf("post-cap layer count mismatch: have %d, want %d", n, 1)
+		fmt.Println(snaps.layers)
 	}
 }
 
@@ -93,6 +101,9 @@ func TestDiskLayerExternalInvalidationPartialFlatten(t *testing.T) {
 	if err := snaps.Update(common.HexToHash("0x03"), common.HexToHash("0x02"), accounts, storage); err != nil {
 		t.Fatalf("failed to create a diff layer: %v", err)
 	}
+	if n := len(snaps.layers); n != 3 {
+		t.Errorf("pre-cap layer count mismatch: have %d, want %d", n, 3)
+	}
 	// Commit the diff layer onto the disk and ensure it's persisted
 	if err := snaps.Cap(common.HexToHash("0x03"), 2, 0); err != nil {
 		t.Fatalf("failed to merge diff layer onto disk: %v", err)
@@ -103,6 +114,10 @@ func TestDiskLayerExternalInvalidationPartialFlatten(t *testing.T) {
 	}
 	if slot, err := ref.Storage(common.HexToHash("0xa1"), common.HexToHash("0xb1")); err != ErrSnapshotStale {
 		t.Errorf("stale reference returned storage slot: %#x (err: %v)", slot, err)
+	}
+	if n := len(snaps.layers); n != 2 {
+		t.Errorf("post-cap layer count mismatch: have %d, want %d", n, 2)
+		fmt.Println(snaps.layers)
 	}
 }
 
@@ -133,10 +148,13 @@ func TestDiffLayerExternalInvalidationFullFlatten(t *testing.T) {
 	if err := snaps.Update(common.HexToHash("0x03"), common.HexToHash("0x02"), accounts, storage); err != nil {
 		t.Fatalf("failed to create a diff layer: %v", err)
 	}
+	if n := len(snaps.layers); n != 3 {
+		t.Errorf("pre-cap layer count mismatch: have %d, want %d", n, 3)
+	}
 	ref := snaps.Snapshot(common.HexToHash("0x02"))
 
 	// Flatten the diff layer into the bottom accumulator
-	if err := snaps.Cap(common.HexToHash("0x03"), 2, 1024*1024); err != nil {
+	if err := snaps.Cap(common.HexToHash("0x03"), 1, 1024*1024); err != nil {
 		t.Fatalf("failed to flatten diff layer into accumulator: %v", err)
 	}
 	// Since the accumulator diff layer was modified, ensure that data retrievald on the external reference fail
@@ -145,6 +163,10 @@ func TestDiffLayerExternalInvalidationFullFlatten(t *testing.T) {
 	}
 	if slot, err := ref.Storage(common.HexToHash("0xa1"), common.HexToHash("0xb1")); err != ErrSnapshotStale {
 		t.Errorf("stale reference returned storage slot: %#x (err: %v)", slot, err)
+	}
+	if n := len(snaps.layers); n != 2 {
+		t.Errorf("post-cap layer count mismatch: have %d, want %d", n, 2)
+		fmt.Println(snaps.layers)
 	}
 }
 
@@ -178,6 +200,9 @@ func TestDiffLayerExternalInvalidationPartialFlatten(t *testing.T) {
 	if err := snaps.Update(common.HexToHash("0x04"), common.HexToHash("0x03"), accounts, storage); err != nil {
 		t.Fatalf("failed to create a diff layer: %v", err)
 	}
+	if n := len(snaps.layers); n != 4 {
+		t.Errorf("pre-cap layer count mismatch: have %d, want %d", n, 4)
+	}
 	ref := snaps.Snapshot(common.HexToHash("0x02"))
 
 	// Flatten the diff layer into the bottom accumulator
@@ -190,5 +215,89 @@ func TestDiffLayerExternalInvalidationPartialFlatten(t *testing.T) {
 	}
 	if slot, err := ref.Storage(common.HexToHash("0xa1"), common.HexToHash("0xb1")); err != ErrSnapshotStale {
 		t.Errorf("stale reference returned storage slot: %#x (err: %v)", slot, err)
+	}
+	if n := len(snaps.layers); n != 3 {
+		t.Errorf("post-cap layer count mismatch: have %d, want %d", n, 3)
+		fmt.Println(snaps.layers)
+	}
+}
+
+// TestPostCapBasicDataAccess tests some functionality regarding capping/flattening.
+func TestPostCapBasicDataAccess(t *testing.T) {
+	// setAccount is a helper to construct a random account entry and assign it to
+	// an account slot in a snapshot
+	setAccount := func(accKey string) map[common.Hash][]byte {
+		return map[common.Hash][]byte{
+			common.HexToHash(accKey): randomAccount(),
+		}
+	}
+	// Create a starting base layer and a snapshot tree out of it
+	cache, _ := bigcache.NewBigCache(bigcache.DefaultConfig(time.Minute))
+	base := &diskLayer{
+		db:    rawdb.NewMemoryDatabase(),
+		root:  common.HexToHash("0x01"),
+		cache: cache,
+	}
+	snaps := &SnapshotTree{
+		layers: map[common.Hash]snapshot{
+			base.root: base,
+		},
+	}
+	// The lowest difflayer
+	snaps.Update(common.HexToHash("0xa1"), common.HexToHash("0x01"), setAccount("0xa1"), nil)
+	snaps.Update(common.HexToHash("0xa2"), common.HexToHash("0xa1"), setAccount("0xa2"), nil)
+	snaps.Update(common.HexToHash("0xb2"), common.HexToHash("0xa1"), setAccount("0xb2"), nil)
+
+	snaps.Update(common.HexToHash("0xa3"), common.HexToHash("0xa2"), setAccount("0xa3"), nil)
+	snaps.Update(common.HexToHash("0xb3"), common.HexToHash("0xb2"), setAccount("0xb3"), nil)
+
+	// checkExist verifies if an account exiss in a snapshot
+	checkExist := func(layer *diffLayer, key string) error {
+		if data, _ := layer.Account(common.HexToHash(key)); data == nil {
+			return fmt.Errorf("expected %x to exist, got nil", common.HexToHash(key))
+		}
+		return nil
+	}
+	// shouldErr checks that an account access errors as expected
+	shouldErr := func(layer *diffLayer, key string) error {
+		if data, err := layer.Account(common.HexToHash(key)); err == nil {
+			return fmt.Errorf("expected error, got data %x", data)
+		}
+		return nil
+	}
+	// check basics
+	snap := snaps.Snapshot(common.HexToHash("0xb3")).(*diffLayer)
+
+	if err := checkExist(snap, "0xa1"); err != nil {
+		t.Error(err)
+	}
+	if err := checkExist(snap, "0xb2"); err != nil {
+		t.Error(err)
+	}
+	if err := checkExist(snap, "0xb3"); err != nil {
+		t.Error(err)
+	}
+	// Now, merge the a-chain
+	snaps.Cap(common.HexToHash("0xa3"), 0, 1024)
+
+	// At this point, a2 got merged into a1. Thus, a1 is now modified, and as a1 is
+	// the parent of b2, b2 should no longer be able to iterate into parent.
+
+	// These should still be accessible
+	if err := checkExist(snap, "0xb2"); err != nil {
+		t.Error(err)
+	}
+	if err := checkExist(snap, "0xb3"); err != nil {
+		t.Error(err)
+	}
+	// But these would need iteration into the modified parent
+	if err := shouldErr(snap, "0xa1"); err != nil {
+		t.Error(err)
+	}
+	if err := shouldErr(snap, "0xa2"); err != nil {
+		t.Error(err)
+	}
+	if err := shouldErr(snap, "0xa3"); err != nil {
+		t.Error(err)
 	}
 }

--- a/core/state/snapshot/snapshot_test.go
+++ b/core/state/snapshot/snapshot_test.go
@@ -15,3 +15,93 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 package snapshot
+
+import (
+	"testing"
+	"time"
+
+	"github.com/allegro/bigcache"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+)
+
+// Tests that if a disk layer becomes stale, no active external references will
+// be returned with junk data. This version of the test flattens every diff layer
+// to check internal corner case around the bottom-most memory accumulator.
+func TestDiskLayerExternalInvalidationFullFlatten(t *testing.T) {
+	// Create an empty base layer and a snapshot tee out of it
+	cache, _ := bigcache.NewBigCache(bigcache.DefaultConfig(time.Minute))
+	base := &diskLayer{
+		db:    rawdb.NewMemoryDatabase(),
+		root:  common.HexToHash("0x01"),
+		cache: cache,
+	}
+	snaps := &SnapshotTree{
+		layers: map[common.Hash]snapshot{
+			base.root: base,
+		},
+	}
+	// Retrieve a reference to the base and commit a diff on top
+	ref := snaps.Snapshot(base.root)
+
+	accounts := map[common.Hash][]byte{
+		common.HexToHash("0xa1"): randomAccount(),
+	}
+	storage := make(map[common.Hash]map[common.Hash][]byte)
+	if err := snaps.Update(common.HexToHash("0x02"), common.HexToHash("0x01"), accounts, storage); err != nil {
+		t.Fatalf("failed to create a diff layer: %v", err)
+	}
+	// Commit the diff layer onto the disk and ensure it's persisted
+	if err := snaps.Cap(common.HexToHash("0x02"), 1, 0); err != nil {
+		t.Fatalf("failed to merge diff layer onto disk: %v", err)
+	}
+	// Since the base layer was modified, ensure that data retrievald on the external reference fail
+	if acc, err := ref.Account(common.HexToHash("0x01")); err != ErrSnapshotStale {
+		t.Errorf("stale reference returned account: %#x (err: %v)", acc, err)
+	}
+	if slot, err := ref.Storage(common.HexToHash("0xa1"), common.HexToHash("0xb1")); err != ErrSnapshotStale {
+		t.Errorf("stale reference returned storage slot: %#x (err: %v)", slot, err)
+	}
+}
+
+// Tests that if a disk layer becomes stale, no active external references will
+// be returned with junk data. This version of the test retains the bottom diff
+// layer to check the usual mode of operation where the accumulator is retained.
+func TestDiskLayerExternalInvalidationPartialFlatten(t *testing.T) {
+	// Create an empty base layer and a snapshot tee out of it
+	cache, _ := bigcache.NewBigCache(bigcache.DefaultConfig(time.Minute))
+	base := &diskLayer{
+		db:    rawdb.NewMemoryDatabase(),
+		root:  common.HexToHash("0x01"),
+		cache: cache,
+	}
+	snaps := &SnapshotTree{
+		layers: map[common.Hash]snapshot{
+			base.root: base,
+		},
+	}
+	// Retrieve a reference to the base and commit a diff on top
+	ref := snaps.Snapshot(base.root)
+
+	accounts := map[common.Hash][]byte{
+		common.HexToHash("0xa1"): randomAccount(),
+	}
+	storage := make(map[common.Hash]map[common.Hash][]byte)
+	if err := snaps.Update(common.HexToHash("0x02"), common.HexToHash("0x01"), accounts, storage); err != nil {
+		t.Fatalf("failed to create a diff layer: %v", err)
+	}
+	if err := snaps.Update(common.HexToHash("0x03"), common.HexToHash("0x02"), accounts, storage); err != nil {
+		t.Fatalf("failed to create a diff layer: %v", err)
+	}
+	// Commit the diff layer onto the disk and ensure it's persisted
+	if err := snaps.Cap(common.HexToHash("0x03"), 2, 0); err != nil {
+		t.Fatalf("failed to merge diff layer onto disk: %v", err)
+	}
+	// Since the base layer was modified, ensure that data retrievald on the external reference fail
+	if acc, err := ref.Account(common.HexToHash("0x01")); err != ErrSnapshotStale {
+		t.Errorf("stale reference returned account: %#x (err: %v)", acc, err)
+	}
+	if slot, err := ref.Storage(common.HexToHash("0xa1"), common.HexToHash("0xb1")); err != ErrSnapshotStale {
+		t.Errorf("stale reference returned storage slot: %#x (err: %v)", slot, err)
+	}
+}

--- a/core/state/snapshot/snapshot_test.go
+++ b/core/state/snapshot/snapshot_test.go
@@ -29,7 +29,7 @@ import (
 // be returned with junk data. This version of the test flattens every diff layer
 // to check internal corner case around the bottom-most memory accumulator.
 func TestDiskLayerExternalInvalidationFullFlatten(t *testing.T) {
-	// Create an empty base layer and a snapshot tee out of it
+	// Create an empty base layer and a snapshot tree out of it
 	cache, _ := bigcache.NewBigCache(bigcache.DefaultConfig(time.Minute))
 	base := &diskLayer{
 		db:    rawdb.NewMemoryDatabase(),
@@ -68,7 +68,7 @@ func TestDiskLayerExternalInvalidationFullFlatten(t *testing.T) {
 // be returned with junk data. This version of the test retains the bottom diff
 // layer to check the usual mode of operation where the accumulator is retained.
 func TestDiskLayerExternalInvalidationPartialFlatten(t *testing.T) {
-	// Create an empty base layer and a snapshot tee out of it
+	// Create an empty base layer and a snapshot tree out of it
 	cache, _ := bigcache.NewBigCache(bigcache.DefaultConfig(time.Minute))
 	base := &diskLayer{
 		db:    rawdb.NewMemoryDatabase(),
@@ -80,7 +80,7 @@ func TestDiskLayerExternalInvalidationPartialFlatten(t *testing.T) {
 			base.root: base,
 		},
 	}
-	// Retrieve a reference to the base and commit a diff on top
+	// Retrieve a reference to the base and commit two diffs on top
 	ref := snaps.Snapshot(base.root)
 
 	accounts := map[common.Hash][]byte{
@@ -98,6 +98,93 @@ func TestDiskLayerExternalInvalidationPartialFlatten(t *testing.T) {
 		t.Fatalf("failed to merge diff layer onto disk: %v", err)
 	}
 	// Since the base layer was modified, ensure that data retrievald on the external reference fail
+	if acc, err := ref.Account(common.HexToHash("0x01")); err != ErrSnapshotStale {
+		t.Errorf("stale reference returned account: %#x (err: %v)", acc, err)
+	}
+	if slot, err := ref.Storage(common.HexToHash("0xa1"), common.HexToHash("0xb1")); err != ErrSnapshotStale {
+		t.Errorf("stale reference returned storage slot: %#x (err: %v)", slot, err)
+	}
+}
+
+// Tests that if a diff layer becomes stale, no active external references will
+// be returned with junk data. This version of the test flattens every diff layer
+// to check internal corner case around the bottom-most memory accumulator.
+func TestDiffLayerExternalInvalidationFullFlatten(t *testing.T) {
+	// Create an empty base layer and a snapshot tree out of it
+	cache, _ := bigcache.NewBigCache(bigcache.DefaultConfig(time.Minute))
+	base := &diskLayer{
+		db:    rawdb.NewMemoryDatabase(),
+		root:  common.HexToHash("0x01"),
+		cache: cache,
+	}
+	snaps := &SnapshotTree{
+		layers: map[common.Hash]snapshot{
+			base.root: base,
+		},
+	}
+	// Commit two diffs on top and retrieve a reference to the bottommost
+	accounts := map[common.Hash][]byte{
+		common.HexToHash("0xa1"): randomAccount(),
+	}
+	storage := make(map[common.Hash]map[common.Hash][]byte)
+	if err := snaps.Update(common.HexToHash("0x02"), common.HexToHash("0x01"), accounts, storage); err != nil {
+		t.Fatalf("failed to create a diff layer: %v", err)
+	}
+	if err := snaps.Update(common.HexToHash("0x03"), common.HexToHash("0x02"), accounts, storage); err != nil {
+		t.Fatalf("failed to create a diff layer: %v", err)
+	}
+	ref := snaps.Snapshot(common.HexToHash("0x02"))
+
+	// Flatten the diff layer into the bottom accumulator
+	if err := snaps.Cap(common.HexToHash("0x03"), 2, 1024*1024); err != nil {
+		t.Fatalf("failed to flatten diff layer into accumulator: %v", err)
+	}
+	// Since the accumulator diff layer was modified, ensure that data retrievald on the external reference fail
+	if acc, err := ref.Account(common.HexToHash("0x01")); err != ErrSnapshotStale {
+		t.Errorf("stale reference returned account: %#x (err: %v)", acc, err)
+	}
+	if slot, err := ref.Storage(common.HexToHash("0xa1"), common.HexToHash("0xb1")); err != ErrSnapshotStale {
+		t.Errorf("stale reference returned storage slot: %#x (err: %v)", slot, err)
+	}
+}
+
+// Tests that if a diff layer becomes stale, no active external references will
+// be returned with junk data. This version of the test retains the bottom diff
+// layer to check the usual mode of operation where the accumulator is retained.
+func TestDiffLayerExternalInvalidationPartialFlatten(t *testing.T) {
+	// Create an empty base layer and a snapshot tree out of it
+	cache, _ := bigcache.NewBigCache(bigcache.DefaultConfig(time.Minute))
+	base := &diskLayer{
+		db:    rawdb.NewMemoryDatabase(),
+		root:  common.HexToHash("0x01"),
+		cache: cache,
+	}
+	snaps := &SnapshotTree{
+		layers: map[common.Hash]snapshot{
+			base.root: base,
+		},
+	}
+	// Commit three diffs on top and retrieve a reference to the bottommost
+	accounts := map[common.Hash][]byte{
+		common.HexToHash("0xa1"): randomAccount(),
+	}
+	storage := make(map[common.Hash]map[common.Hash][]byte)
+	if err := snaps.Update(common.HexToHash("0x02"), common.HexToHash("0x01"), accounts, storage); err != nil {
+		t.Fatalf("failed to create a diff layer: %v", err)
+	}
+	if err := snaps.Update(common.HexToHash("0x03"), common.HexToHash("0x02"), accounts, storage); err != nil {
+		t.Fatalf("failed to create a diff layer: %v", err)
+	}
+	if err := snaps.Update(common.HexToHash("0x04"), common.HexToHash("0x03"), accounts, storage); err != nil {
+		t.Fatalf("failed to create a diff layer: %v", err)
+	}
+	ref := snaps.Snapshot(common.HexToHash("0x02"))
+
+	// Flatten the diff layer into the bottom accumulator
+	if err := snaps.Cap(common.HexToHash("0x04"), 2, 1024*1024); err != nil {
+		t.Fatalf("failed to flatten diff layer into accumulator: %v", err)
+	}
+	// Since the accumulator diff layer was modified, ensure that data retrievald on the external reference fail
 	if acc, err := ref.Account(common.HexToHash("0x01")); err != ErrSnapshotStale {
 		t.Errorf("stale reference returned account: %#x (err: %v)", acc, err)
 	}

--- a/core/state/snapshot/snapshot_test.go
+++ b/core/state/snapshot/snapshot_test.go
@@ -277,6 +277,10 @@ func TestPostCapBasicDataAccess(t *testing.T) {
 	if err := checkExist(snap, "0xb3"); err != nil {
 		t.Error(err)
 	}
+	// Cap to a bad root should fail
+	if err := snaps.Cap(common.HexToHash("0x1337"), 0, 1024); err == nil {
+		t.Errorf("expected error, got none")
+	}
 	// Now, merge the a-chain
 	snaps.Cap(common.HexToHash("0xa3"), 0, 1024)
 

--- a/core/state/snapshot/sort.go
+++ b/core/state/snapshot/sort.go
@@ -1,0 +1,62 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshot
+
+import (
+	"bytes"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// hashes is a helper to implement sort.Interface.
+type hashes []common.Hash
+
+// Len is the number of elements in the collection.
+func (hs hashes) Len() int { return len(hs) }
+
+// Less reports whether the element with index i should sort before the element
+// with index j.
+func (hs hashes) Less(i, j int) bool { return bytes.Compare(hs[i][:], hs[j][:]) < 0 }
+
+// Swap swaps the elements with indexes i and j.
+func (hs hashes) Swap(i, j int) { hs[i], hs[j] = hs[j], hs[i] }
+
+// merge combines two sorted lists of hashes into a combo sorted one.
+func merge(a, b []common.Hash) []common.Hash {
+	result := make([]common.Hash, len(a)+len(b))
+
+	i := 0
+	for len(a) > 0 && len(b) > 0 {
+		if bytes.Compare(a[0][:], b[0][:]) < 0 {
+			result[i] = a[0]
+			a = a[1:]
+		} else {
+			result[i] = b[0]
+			b = b[1:]
+		}
+		i++
+	}
+	for j := 0; j < len(a); j++ {
+		result[i] = a[j]
+		i++
+	}
+	for j := 0; j < len(b); j++ {
+		result[i] = b[j]
+		i++
+	}
+	return result
+}

--- a/core/state/snapshot/sort.go
+++ b/core/state/snapshot/sort.go
@@ -60,3 +60,33 @@ func merge(a, b []common.Hash) []common.Hash {
 	}
 	return result
 }
+
+// dedupMerge combines two sorted lists of hashes into a combo sorted one,
+// and removes duplicates in the process
+func dedupMerge(a, b []common.Hash) []common.Hash {
+	result := make([]common.Hash, len(a)+len(b))
+	i := 0
+	for len(a) > 0 && len(b) > 0 {
+		if diff := bytes.Compare(a[0][:], b[0][:]); diff < 0 {
+			result[i] = a[0]
+			a = a[1:]
+		} else {
+			result[i] = b[0]
+			b = b[1:]
+			// If they were equal, progress a too
+			if diff == 0 {
+				a = a[1:]
+			}
+		}
+		i++
+	}
+	for j := 0; j < len(a); j++ {
+		result[i] = a[j]
+		i++
+	}
+	for j := 0; j < len(b); j++ {
+		result[i] = b[j]
+		i++
+	}
+	return result[:i]
+}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -291,6 +291,23 @@ func (s *stateObject) updateTrie(db Database) Trie {
 	if metrics.EnabledExpensive {
 		defer func(start time.Time) { s.db.StorageUpdates += time.Since(start) }(time.Now())
 	}
+	// Retrieve the snapshot storage map for the object
+	var storage map[common.Hash][]byte
+	if s.db.snap != nil {
+		// Retrieve the old storage map, if available
+		s.db.snapLock.RLock()
+		storage = s.db.snapStorage[s.addrHash]
+		s.db.snapLock.RUnlock()
+
+		// If no old storage map was available, create a new one
+		if storage == nil {
+			storage = make(map[common.Hash][]byte)
+
+			s.db.snapLock.Lock()
+			s.db.snapStorage[s.addrHash] = storage
+			s.db.snapLock.Unlock()
+		}
+	}
 	// Insert all the pending updates into the trie
 	tr := s.getTrie(db)
 	for key, value := range s.pendingStorage {
@@ -309,20 +326,7 @@ func (s *stateObject) updateTrie(db Database) Trie {
 			s.setError(tr.TryUpdate(key[:], v))
 		}
 		// If state snapshotting is active, cache the data til commit
-		if s.db.snap != nil {
-			// Retrieve an old storage map, if available
-			s.db.snapLock.RLock()
-			storage := s.db.snapStorage[s.addrHash]
-			s.db.snapLock.RUnlock()
-
-			if storage == nil {
-				// No old storage available, create a new one
-				storage = make(map[common.Hash][]byte)
-
-				s.db.snapLock.Lock()
-				s.db.snapStorage[s.addrHash] = storage
-				s.db.snapLock.Unlock()
-			}
+		if storage != nil {
 			storage[crypto.Keccak256Hash(key[:])] = v // v will be nil if value is 0x00
 		}
 	}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -195,15 +195,26 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 	if value, cached := s.originStorage[key]; cached {
 		return value
 	}
-	// Track the amount of time wasted on reading the storage trie
-	if metrics.EnabledExpensive {
-		defer func(start time.Time) { s.db.StorageReads += time.Since(start) }(time.Now())
-	}
-	// Otherwise load the value from the database
-	enc, err := s.getTrie(db).TryGet(key[:])
-	if err != nil {
-		s.setError(err)
-		return common.Hash{}
+	// If no live objects are available, attempt to use snapshots
+	var (
+		enc []byte
+		err error
+	)
+	if s.db.snap != nil {
+		if metrics.EnabledExpensive {
+			defer func(start time.Time) { s.db.SnapshotStorageReads += time.Since(start) }(time.Now())
+		}
+		enc = s.db.snap.Storage(s.addrHash, crypto.Keccak256Hash(key[:]))
+	} else {
+		// Track the amount of time wasted on reading the storage trie
+		if metrics.EnabledExpensive {
+			defer func(start time.Time) { s.db.StorageReads += time.Since(start) }(time.Now())
+		}
+		// Otherwise load the value from the database
+		if enc, err = s.getTrie(db).TryGet(key[:]); err != nil {
+			s.setError(err)
+			return common.Hash{}
+		}
 	}
 	var value common.Hash
 	if len(enc) > 0 {
@@ -289,13 +300,31 @@ func (s *stateObject) updateTrie(db Database) Trie {
 		}
 		s.originStorage[key] = value
 
+		var v []byte
 		if (value == common.Hash{}) {
 			s.setError(tr.TryDelete(key[:]))
-			continue
+		} else {
+			// Encoding []byte cannot fail, ok to ignore the error.
+			v, _ = rlp.EncodeToBytes(common.TrimLeftZeroes(value[:]))
+			s.setError(tr.TryUpdate(key[:], v))
 		}
-		// Encoding []byte cannot fail, ok to ignore the error.
-		v, _ := rlp.EncodeToBytes(common.TrimLeftZeroes(value[:]))
-		s.setError(tr.TryUpdate(key[:], v))
+		// If state snapshotting is active, cache the data til commit
+		if s.db.snap != nil {
+			// Retrieve an old storage map, if available
+			s.db.snapLock.RLock()
+			storage := s.db.snapStorage[s.addrHash]
+			s.db.snapLock.RUnlock()
+
+			if storage == nil {
+				// No old storage available, create a new one
+				storage = make(map[common.Hash][]byte)
+
+				s.db.snapLock.Lock()
+				s.db.snapStorage[s.addrHash] = storage
+				s.db.snapLock.Unlock()
+			}
+			storage[crypto.Keccak256Hash(key[:])] = v // v will be nil if value is 0x00
+		}
 	}
 	if len(s.pendingStorage) > 0 {
 		s.pendingStorage = make(Storage)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -510,25 +510,31 @@ func (s *StateDB) getDeletedStateObject(addr common.Address) *stateObject {
 		return obj
 	}
 	// If no live objects are available, attempt to use snapshots
-	var data Account
+	var (
+		data Account
+		err  error
+	)
 	if s.snap != nil {
 		if metrics.EnabledExpensive {
 			defer func(start time.Time) { s.SnapshotAccountReads += time.Since(start) }(time.Now())
 		}
-		acc := s.snap.Account(crypto.Keccak256Hash(addr[:]))
-		if acc == nil {
-			return nil
+		var acc *snapshot.Account
+		if acc, err = s.snap.Account(crypto.Keccak256Hash(addr[:])); err == nil {
+			if acc == nil {
+				return nil
+			}
+			data.Nonce, data.Balance, data.CodeHash = acc.Nonce, acc.Balance, acc.CodeHash
+			if len(data.CodeHash) == 0 {
+				data.CodeHash = emptyCodeHash
+			}
+			data.Root = common.BytesToHash(acc.Root)
+			if data.Root == (common.Hash{}) {
+				data.Root = emptyRoot
+			}
 		}
-		data.Nonce, data.Balance, data.CodeHash = acc.Nonce, acc.Balance, acc.CodeHash
-		if len(data.CodeHash) == 0 {
-			data.CodeHash = emptyCodeHash
-		}
-		data.Root = common.BytesToHash(acc.Root)
-		if data.Root == (common.Hash{}) {
-			data.Root = emptyRoot
-		}
-	} else {
-		// Snapshot unavailable, fall back to the trie
+	}
+	// If snapshot unavailable or reading from it failed, load from the database
+	if s.snap == nil || err != nil {
 		if metrics.EnabledExpensive {
 			defer func(start time.Time) { s.AccountReads += time.Since(start) }(time.Now())
 		}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -22,9 +22,11 @@ import (
 	"fmt"
 	"math/big"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -66,6 +68,12 @@ type StateDB struct {
 	db   Database
 	trie Trie
 
+	snaps        *snapshot.SnapshotTree
+	snap         snapshot.Snapshot
+	snapAccounts map[common.Hash][]byte
+	snapStorage  map[common.Hash]map[common.Hash][]byte
+	snapLock     sync.RWMutex // Lock for the concurrent storage updaters
+
 	// This map holds 'live' objects, which will get modified while processing a state transition.
 	stateObjects        map[common.Address]*stateObject
 	stateObjectsPending map[common.Address]struct{} // State objects finalized but not yet written to the trie
@@ -95,32 +103,43 @@ type StateDB struct {
 	nextRevisionId int
 
 	// Measurements gathered during execution for debugging purposes
-	AccountReads   time.Duration
-	AccountHashes  time.Duration
-	AccountUpdates time.Duration
-	AccountCommits time.Duration
-	StorageReads   time.Duration
-	StorageHashes  time.Duration
-	StorageUpdates time.Duration
-	StorageCommits time.Duration
+	AccountReads         time.Duration
+	AccountHashes        time.Duration
+	AccountUpdates       time.Duration
+	AccountCommits       time.Duration
+	StorageReads         time.Duration
+	StorageHashes        time.Duration
+	StorageUpdates       time.Duration
+	StorageCommits       time.Duration
+	SnapshotAccountReads time.Duration
+	SnapshotStorageReads time.Duration
+	SnapshotCommits      time.Duration
 }
 
 // Create a new state from a given trie.
-func New(root common.Hash, db Database) (*StateDB, error) {
+func New(root common.Hash, db Database, snaps *snapshot.SnapshotTree) (*StateDB, error) {
 	tr, err := db.OpenTrie(root)
 	if err != nil {
 		return nil, err
 	}
-	return &StateDB{
+	sdb := &StateDB{
 		db:                  db,
 		trie:                tr,
+		snaps:               snaps,
 		stateObjects:        make(map[common.Address]*stateObject),
 		stateObjectsPending: make(map[common.Address]struct{}),
 		stateObjectsDirty:   make(map[common.Address]struct{}),
 		logs:                make(map[common.Hash][]*types.Log),
 		preimages:           make(map[common.Hash][]byte),
 		journal:             newJournal(),
-	}, nil
+	}
+	if sdb.snaps != nil {
+		if sdb.snap = sdb.snaps.Snapshot(root); sdb.snap != nil {
+			sdb.snapAccounts = make(map[common.Hash][]byte)
+			sdb.snapStorage = make(map[common.Hash]map[common.Hash][]byte)
+		}
+	}
+	return sdb, nil
 }
 
 // setError remembers the first non-nil error it is called with.
@@ -152,6 +171,14 @@ func (self *StateDB) Reset(root common.Hash) error {
 	self.logSize = 0
 	self.preimages = make(map[common.Hash][]byte)
 	self.clearJournalAndRefund()
+
+	if self.snaps != nil {
+		self.snapAccounts, self.snapStorage = nil, nil
+		if self.snap = self.snaps.Snapshot(root); self.snap != nil {
+			self.snapAccounts = make(map[common.Hash][]byte)
+			self.snapStorage = make(map[common.Hash]map[common.Hash][]byte)
+		}
+	}
 	return nil
 }
 
@@ -437,6 +464,11 @@ func (s *StateDB) updateStateObject(obj *stateObject) {
 		panic(fmt.Errorf("can't encode object at %x: %v", addr[:], err))
 	}
 	s.setError(s.trie.TryUpdate(addr[:], data))
+
+	// If state snapshotting is active, cache the data til commit
+	if s.snap != nil {
+		s.snapAccounts[obj.addrHash] = snapshot.AccountRLP(obj.data.Nonce, obj.data.Balance, obj.data.Root, obj.data.CodeHash)
+	}
 }
 
 // deleteStateObject removes the given object from the state trie.
@@ -448,6 +480,11 @@ func (s *StateDB) deleteStateObject(obj *stateObject) {
 	// Delete the account from the trie
 	addr := obj.Address()
 	s.setError(s.trie.TryDelete(addr[:]))
+
+	// If state snapshotting is active, cache the data til commit
+	if s.snap != nil {
+		s.snapAccounts[obj.addrHash] = nil // Yes, nil means deleted
+	}
 }
 
 // getStateObject retrieves a state object given by the address, returning nil if
@@ -469,20 +506,38 @@ func (s *StateDB) getDeletedStateObject(addr common.Address) *stateObject {
 	if obj := s.stateObjects[addr]; obj != nil {
 		return obj
 	}
-	// Track the amount of time wasted on loading the object from the database
-	if metrics.EnabledExpensive {
-		defer func(start time.Time) { s.AccountReads += time.Since(start) }(time.Now())
-	}
-	// Load the object from the database
-	enc, err := s.trie.TryGet(addr[:])
-	if len(enc) == 0 {
-		s.setError(err)
-		return nil
-	}
+	// If no live objects are available, attempt to use snapshots
 	var data Account
-	if err := rlp.DecodeBytes(enc, &data); err != nil {
-		log.Error("Failed to decode state object", "addr", addr, "err", err)
-		return nil
+	if s.snap != nil {
+		if metrics.EnabledExpensive {
+			defer func(start time.Time) { s.SnapshotAccountReads += time.Since(start) }(time.Now())
+		}
+		acc := s.snap.Account(crypto.Keccak256Hash(addr[:]))
+		if acc == nil {
+			return nil
+		}
+		data.Nonce, data.Balance, data.CodeHash = acc.Nonce, acc.Balance, acc.CodeHash
+		if len(data.CodeHash) == 0 {
+			data.CodeHash = emptyCodeHash
+		}
+		data.Root = common.BytesToHash(acc.Root)
+		if data.Root == (common.Hash{}) {
+			data.Root = emptyRoot
+		}
+	} else {
+		// Snapshot unavailable, fall back to the trie
+		if metrics.EnabledExpensive {
+			defer func(start time.Time) { s.AccountReads += time.Since(start) }(time.Now())
+		}
+		enc, err := s.trie.TryGet(addr[:])
+		if len(enc) == 0 {
+			s.setError(err)
+			return nil
+		}
+		if err := rlp.DecodeBytes(enc, &data); err != nil {
+			log.Error("Failed to decode state object", "addr", addr, "err", err)
+			return nil
+		}
 	}
 	// Insert into the live set
 	obj := newObject(s, addr, data)
@@ -747,10 +802,11 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 		s.stateObjectsDirty = make(map[common.Address]struct{})
 	}
 	// Write the account trie changes, measuing the amount of wasted time
+	var start time.Time
 	if metrics.EnabledExpensive {
-		defer func(start time.Time) { s.AccountCommits += time.Since(start) }(time.Now())
+		start = time.Now()
 	}
-	return s.trie.Commit(func(leaf []byte, parent common.Hash) error {
+	root, err := s.trie.Commit(func(leaf []byte, parent common.Hash) error {
 		var account Account
 		if err := rlp.DecodeBytes(leaf, &account); err != nil {
 			return nil
@@ -764,4 +820,22 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 		}
 		return nil
 	})
+	if metrics.EnabledExpensive {
+		s.AccountCommits += time.Since(start)
+	}
+	// If snapshotting is enabled, update the snapshot tree with this new version
+	if s.snap != nil {
+		if metrics.EnabledExpensive {
+			defer func(start time.Time) { s.SnapshotCommits += time.Since(start) }(time.Now())
+		}
+		_, parentRoot := s.snap.Info()
+		if err := s.snaps.Update(root, parentRoot, s.snapAccounts, s.snapStorage); err != nil {
+			log.Warn("Failed to update snapshot tree", "from", parentRoot, "to", root, "err", err)
+		}
+		if err := s.snaps.Cap(root, 16, 4*1024*1024); err != nil {
+			log.Warn("Failed to cap snapshot tree", "root", root, "layers", 16, "memory", 4*1024*1024, "err", err)
+		}
+		s.snap, s.snapAccounts, s.snapStorage = nil, nil, nil
+	}
+	return root, err
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -483,7 +483,10 @@ func (s *StateDB) deleteStateObject(obj *stateObject) {
 
 	// If state snapshotting is active, cache the data til commit
 	if s.snap != nil {
-		s.snapAccounts[obj.addrHash] = nil // Yes, nil means deleted
+		s.snapLock.Lock()
+		s.snapAccounts[obj.addrHash] = nil // We need to maintain account deletions explicitly
+		s.snapStorage[obj.addrHash] = nil  // We need to maintain storage deletions explicitly
+		s.snapLock.Unlock()
 	}
 }
 

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -65,6 +65,8 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 			return // Ugh, something went horribly wrong, bail out
 		}
 	}
+	// All transactions processed, finalize the block to force loading written-only trie paths
+	statedb.Finalise(true) // TODO(karalabe): should we run this on interrupt too?
 }
 
 // precacheTransaction attempts to apply a transaction to the given state database

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -99,7 +99,7 @@ func Execute(code, input []byte, cfg *Config) ([]byte, *state.StateDB, error) {
 	setDefaults(cfg)
 
 	if cfg.State == nil {
-		cfg.State, _ = state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()))
+		cfg.State, _ = state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
 	}
 	var (
 		address = common.BytesToAddress([]byte("contract"))
@@ -129,7 +129,7 @@ func Create(input []byte, cfg *Config) ([]byte, common.Address, uint64, error) {
 	setDefaults(cfg)
 
 	if cfg.State == nil {
-		cfg.State, _ = state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()))
+		cfg.State, _ = state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
 	}
 	var (
 		vmenv  = NewEnv(cfg)

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -95,7 +95,7 @@ func TestExecute(t *testing.T) {
 }
 
 func TestCall(t *testing.T) {
-	state, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()))
+	state, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
 	address := common.HexToAddress("0x0a")
 	state.SetCode(address, []byte{
 		byte(vm.PUSH1), 10,
@@ -151,7 +151,7 @@ func BenchmarkCall(b *testing.B) {
 }
 func benchmarkEVM_Create(bench *testing.B, code string) {
 	var (
-		statedb, _ = state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()))
+		statedb, _ = state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
 		sender     = common.BytesToAddress([]byte("sender"))
 		receiver   = common.BytesToAddress([]byte("receiver"))
 	)

--- a/eth/api_test.go
+++ b/eth/api_test.go
@@ -64,7 +64,7 @@ func (h resultHash) Less(i, j int) bool { return bytes.Compare(h[i].Bytes(), h[j
 func TestAccountRange(t *testing.T) {
 	var (
 		statedb  = state.NewDatabase(rawdb.NewMemoryDatabase())
-		state, _ = state.New(common.Hash{}, statedb)
+		state, _ = state.New(common.Hash{}, statedb, nil)
 		addrs    = [AccountRangeMaxResults * 2]common.Address{}
 		m        = map[common.Address]bool{}
 	)
@@ -162,7 +162,7 @@ func TestAccountRange(t *testing.T) {
 func TestEmptyAccountRange(t *testing.T) {
 	var (
 		statedb  = state.NewDatabase(rawdb.NewMemoryDatabase())
-		state, _ = state.New(common.Hash{}, statedb)
+		state, _ = state.New(common.Hash{}, statedb, nil)
 	)
 
 	state.Commit(true)
@@ -188,7 +188,7 @@ func TestEmptyAccountRange(t *testing.T) {
 func TestStorageRangeAt(t *testing.T) {
 	// Create a state where account 0x010000... has a few storage entries.
 	var (
-		state, _ = state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()))
+		state, _ = state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
 		addr     = common.Address{0x01}
 		keys     = []common.Hash{ // hashes of Keys of storage
 			common.HexToHash("340dd630ad21bf010b4e676dbfa9ba9a02175262d1fa356232cfde6cb5b47ef2"),

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -155,7 +155,7 @@ func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Bl
 			return nil, fmt.Errorf("parent block #%d not found", number-1)
 		}
 	}
-	statedb, err := state.New(start.Root(), database)
+	statedb, err := state.New(start.Root(), database, nil)
 	if err != nil {
 		// If the starting state is missing, allow some number of blocks to be reexecuted
 		reexec := defaultTraceReexec
@@ -168,7 +168,7 @@ func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Bl
 			if start == nil {
 				break
 			}
-			if statedb, err = state.New(start.Root(), database); err == nil {
+			if statedb, err = state.New(start.Root(), database, nil); err == nil {
 				break
 			}
 		}
@@ -648,7 +648,7 @@ func (api *PrivateDebugAPI) computeStateDB(block *types.Block, reexec uint64) (*
 		if block == nil {
 			break
 		}
-		if statedb, err = state.New(block.Root(), database); err == nil {
+		if statedb, err = state.New(block.Root(), database, nil); err == nil {
 			break
 		}
 	}

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -348,7 +348,7 @@ func testGetNodeData(t *testing.T, protocol int) {
 	}
 	accounts := []common.Address{testBank, acc1Addr, acc2Addr}
 	for i := uint64(0); i <= pm.blockchain.CurrentBlock().NumberU64(); i++ {
-		trie, _ := state.New(pm.blockchain.GetBlockByNumber(i).Root(), state.NewDatabase(statedb))
+		trie, _ := state.New(pm.blockchain.GetBlockByNumber(i).Root(), state.NewDatabase(statedb), nil)
 
 		for j, acc := range accounts {
 			state, _ := pm.blockchain.State()

--- a/light/odr_test.go
+++ b/light/odr_test.go
@@ -149,7 +149,7 @@ func odrAccounts(ctx context.Context, db ethdb.Database, bc *core.BlockChain, lc
 		st = NewState(ctx, header, lc.Odr())
 	} else {
 		header := bc.GetHeaderByHash(bhash)
-		st, _ = state.New(header.Root, state.NewDatabase(db))
+		st, _ = state.New(header.Root, state.NewDatabase(db), nil)
 	}
 
 	var res []byte
@@ -189,7 +189,7 @@ func odrContractCall(ctx context.Context, db ethdb.Database, bc *core.BlockChain
 		} else {
 			chain = bc
 			header = bc.GetHeaderByHash(bhash)
-			st, _ = state.New(header.Root, state.NewDatabase(db))
+			st, _ = state.New(header.Root, state.NewDatabase(db), nil)
 		}
 
 		// Perform read-only call.

--- a/light/trie.go
+++ b/light/trie.go
@@ -30,7 +30,7 @@ import (
 )
 
 func NewState(ctx context.Context, head *types.Header, odr OdrBackend) *state.StateDB {
-	state, _ := state.New(head.Root, NewStateDatabase(ctx, head, odr))
+	state, _ := state.New(head.Root, NewStateDatabase(ctx, head, odr), nil)
 	return state
 }
 

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -206,7 +206,7 @@ func (t *StateTest) gasLimit(subtest StateSubtest) uint64 {
 
 func MakePreState(db ethdb.Database, accounts core.GenesisAlloc) *state.StateDB {
 	sdb := state.NewDatabase(db)
-	statedb, _ := state.New(common.Hash{}, sdb)
+	statedb, _ := state.New(common.Hash{}, sdb, nil)
 	for addr, a := range accounts {
 		statedb.SetCode(addr, a.Code)
 		statedb.SetNonce(addr, a.Nonce)
@@ -217,7 +217,7 @@ func MakePreState(db ethdb.Database, accounts core.GenesisAlloc) *state.StateDB 
 	}
 	// Commit and re-open to start with a clean state.
 	root, _ := statedb.Commit(false)
-	statedb, _ = state.New(root, sdb)
+	statedb, _ = state.New(root, sdb, nil)
 	return statedb
 }
 

--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -29,6 +29,7 @@ import (
 type Iterator struct {
 	nodeIt NodeIterator
 
+	Nodes int    // Number of nodes iterated over
 	Key   []byte // Current data key on which the iterator is positioned on
 	Value []byte // Current data value on which the iterator is positioned on
 	Err   error
@@ -46,6 +47,7 @@ func NewIterator(it NodeIterator) *Iterator {
 // Next moves the iterator forward one key-value entry.
 func (it *Iterator) Next() bool {
 	for it.nodeIt.Next(true) {
+		it.Nodes++
 		if it.nodeIt.Leaf() {
 			it.Key = it.nodeIt.LeafKey()
 			it.Value = it.nodeIt.LeafBlob()


### PR DESCRIPTION
This PR tests a different binary format for journals. The benchmark is based on, 
- 128 layers, 
- each with 200 accounts, which each has
- 200 storage slots. 

In total about 320 Mb of data. 

With RLP-encoding:
```

[user@work snapshot]$ go test -bench BenchmarkJournal -run - -benchmem
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/state/snapshot
BenchmarkJournal-6   	       1	1119407281 ns/op	503882328 B/op	 5284719 allocs/op
PASS
ok  	github.com/ethereum/go-ethereum/core/state/snapshot	4.537s
```
With a custom binary encoding (this PR):
```
[user@work snapshot]$ go test -bench BenchmarkJournal -run - -benchmem
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/state/snapshot
BenchmarkJournal-6   	       2	 577773937 ns/op	174854784 B/op	10237093 allocs/op
PASS
```

These benchmarks do not include writing to disk (I used the noop-writer) -- but adding disk writes doesn't change a whole lot (that doesn't seem to be the bottleneck). 
This PR is not finished by any means, I just wanted to see how much gain there could be had if we use somethign that isn't length-prefixed... 

Don't know if it's worth pursuing... ? 