### PR TITLE
core/state/snapshot: avoid double iteration on accounts/storage

### DIFF
--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -18,7 +18,6 @@ package snapshot
 
 import (
 	"encoding/binary"
-	"fmt"
 	"math"
 	"math/rand"
 	"sort"
@@ -26,7 +25,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/steakknife/bloomfilter"
 )
@@ -151,37 +149,6 @@ func newDiffLayer(parent snapshot, root common.Hash, accounts map[common.Hash][]
 	default:
 		panic("unknown parent type")
 	}
-	// Determine memory size and track the dirty writes
-	for _, data := range accounts {
-		dl.memory += uint64(common.HashLength + len(data))
-		snapshotDirtyAccountWriteMeter.Mark(int64(len(data)))
-	}
-	// Fill the storage hashes and sort them for the iterator
-	dl.storageList = make(map[common.Hash][]common.Hash)
-
-	for accountHash, slots := range storage {
-		// If the slots are nil, sanity check that it's a deleted account
-		if slots == nil {
-			// Ensure that the account was just marked as deleted
-			if account, ok := accounts[accountHash]; account != nil || !ok {
-				panic(fmt.Sprintf("storage in %#x nil, but account conflicts (%#x, exists: %v)", accountHash, account, ok))
-			}
-			// Everything ok, store the deletion mark and continue
-			dl.storageList[accountHash] = nil
-			continue
-		}
-		// Storage slots are not nil so entire contract was not deleted, ensure the
-		// account was just updated.
-		if account, ok := accounts[accountHash]; account == nil || !ok {
-			log.Error(fmt.Sprintf("storage in %#x exists, but account nil (exists: %v)", accountHash, ok))
-		}
-		// Determine memory size and track the dirty writes
-		for _, data := range slots {
-			dl.memory += uint64(common.HashLength + len(data))
-			snapshotDirtyStorageWriteMeter.Mark(int64(len(data)))
-		}
-	}
-	dl.memory += uint64(len(dl.storageList) * common.HashLength)
 	return dl
 }
 
@@ -207,14 +174,27 @@ func (dl *diffLayer) rebloom(origin *diskLayer) {
 		dl.diffed, _ = bloomfilter.New(uint64(bloomSize), uint64(bloomFuncs))
 	}
 	// Iterate over all the accounts and storage slots and index them
-	for hash := range dl.accountData {
+	// Also count memory consumption while we're at it
+	dl.memory = 0
+	dataSize, nHashes := uint64(0), uint64(0)
+	for hash, data := range dl.accountData {
 		dl.diffed.Add(accountBloomHasher(hash))
+		dataSize += uint64(len(data))
+		nHashes++
 	}
+	dl.memory = dataSize + nHashes*uint64(common.HashLength)
+	snapshotDirtyAccountWriteMeter.Mark(int64(dataSize))
+
+	dataSize, nHashes = uint64(0), uint64(0)
 	for accountHash, slots := range dl.storageData {
-		for storageHash := range slots {
+		for storageHash, data := range slots {
 			dl.diffed.Add(storageBloomHasher{accountHash, storageHash})
+			dataSize += uint64(len(data))
+			nHashes++
 		}
 	}
+	dl.memory += dataSize + nHashes*uint64(common.HashLength)
+	snapshotDirtyStorageWriteMeter.Mark(int64(dataSize))
 	// Calculate the current false positive rate and update the error rate meter.
 	// This is a bit cheating because subsequent layers will overwrite it, but it
 	// should be fine, we're only interested in ballpark figures.

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -304,7 +304,7 @@ func (t *Tree) Cap(root common.Hash, layers int) error {
 		var rebloom func(root common.Hash)
 		rebloom = func(root common.Hash) {
 			if diff, ok := t.layers[root].(*diffLayer); ok {
-				diff.rebloom(persisted)
+				diff.rebloom(persisted, false)
 			}
 			for _, child := range children[root] {
 				rebloom(child)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -839,11 +839,12 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 		}
 		// Only update if there's a state transition (skip empty Clique blocks)
 		if parent := s.snap.Root(); parent != root {
+			// We cap first, leaving space for the one we're about to add
+			if err := s.snaps.Cap(root, 127-1); err != nil { // Persistent layer is 128th, the last available trie
+				log.Warn("Failed to cap snapshot tree", "root", root, "layers", 127-1, "err", err)
+			}
 			if err := s.snaps.Update(root, parent, s.snapAccounts, s.snapStorage); err != nil {
 				log.Warn("Failed to update snapshot tree", "from", parent, "to", root, "err", err)
-			}
-			if err := s.snaps.Cap(root, 127); err != nil { // Persistent layer is 128th, the last available trie
-				log.Warn("Failed to cap snapshot tree", "root", root, "layers", 127, "err", err)
 			}
 		}
 		s.snap, s.snapAccounts, s.snapStorage = nil, nil, nil


### PR DESCRIPTION
This removes some double-work that happens during Update -> new layer