### PR TITLE
cmd, core/state/snapshot: implement journal dumper

### DIFF
--- a/cmd/journaldump/main.go
+++ b/cmd/journaldump/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state/snapshot"
+	"github.com/ethereum/go-ethereum/crypto"
+	"os"
+)
+
+func init() {
+	flag.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage:", os.Args[0], "<datadir>")
+		flag.PrintDefaults()
+		fmt.Fprintln(os.Stderr, `
+Exports the contents of the memory difflayers in the journal`)
+	}
+}
+
+func main() {
+	flag.Parse()
+	var ddir string
+	switch {
+	case flag.NArg() == 1:
+		ddir = flag.Arg(0)
+	default:
+		fmt.Fprintln(os.Stderr, "Error: one argument needed")
+		flag.Usage()
+		os.Exit(2)
+
+	}
+	diskdb, err := rawdb.NewLevelDBDatabase(ddir, 512, 100, "chaindata")
+	if err != nil {
+		fmt.Printf("Error opening db %v\n", err)
+		os.Exit(1)
+	}
+	defer diskdb.Close()
+	err = snapshot.ExportSnapshot(diskdb)
+	if err != nil {
+		fmt.Printf("Error exporting snapshot: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -59,7 +59,7 @@ var (
 	txLookupPrefix        = []byte("l") // txLookupPrefix + hash -> transaction/receipt lookup metadata
 	bloomBitsPrefix       = []byte("B") // bloomBitsPrefix + bit (uint16 big endian) + section (uint64 big endian) + hash -> bloom bits
 	SnapshotAccountPrefix = []byte("a") // SnapshotAccountPrefix + account hash -> account trie value
-	SnapshotStoragePrefix = []byte("s") // SnapshotStoragePrefix + account hash + storage hash -> storage trie value
+	SnapshotStoragePrefix = []byte("o") // SnapshotStoragePrefix + account hash + storage hash -> storage trie value
 
 	preimagePrefix = []byte("secure-key-")      // preimagePrefix + hash -> preimage
 	configPrefix   = []byte("ethereum-config-") // config prefix for the db

--- a/core/state/snapshot/iterator.go
+++ b/core/state/snapshot/iterator.go
@@ -148,9 +148,10 @@ type diskAccountIterator struct {
 
 // AccountIterator creates an account iterator over a disk layer.
 func (dl *diskLayer) AccountIterator(seek common.Hash) AccountIterator {
+	// TOOD: Fix seek position, or remove seek parameter
 	return &diskAccountIterator{
 		layer: dl,
-		it:    dl.diskdb.NewIteratorWithPrefix(append(rawdb.SnapshotAccountPrefix, seek[:]...)),
+		it:    dl.diskdb.NewIteratorWithPrefix(rawdb.SnapshotAccountPrefix),
 	}
 }
 
@@ -160,11 +161,16 @@ func (it *diskAccountIterator) Next() bool {
 	if it.it == nil {
 		return false
 	}
-	// Try to advance the iterator and release it if we reahed the end
-	if !it.it.Next() || !bytes.HasPrefix(it.it.Key(), rawdb.SnapshotAccountPrefix) {
-		it.it.Release()
-		it.it = nil
-		return false
+	// Try to advance the iterator and release it if we reached the end
+	for {
+		if !it.it.Next() || !bytes.HasPrefix(it.it.Key(), rawdb.SnapshotAccountPrefix) {
+			it.it.Release()
+			it.it = nil
+			return false
+		}
+		if len(it.it.Key()) == len(rawdb.SnapshotAccountPrefix)+common.HashLength {
+			break
+		}
 	}
 	return true
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -595,9 +595,12 @@ func (s *StateDB) CreateAccount(addr common.Address) {
 	if prev != nil {
 		newObj.setBalance(prev.data.Balance)
 	}
-	if s.snap != nil && prev != nil {
-		s.snapDestructs[prev.addrHash] = struct{}{}
-	}
+	// This has been removed. A Create action may be cancelled, if the initcode
+	// exits with error. In that case, we would need to clean up the snapDestructs,
+	// Better to not put it there in the first place, if we can get away with it.
+	//if s.snap != nil && prev != nil {
+	//	s.snapDestructs[prev.addrHash] = struct{}{}
+	//}
 }
 
 func (db *StateDB) ForEachStorage(addr common.Address, cb func(key, value common.Hash) bool) error {


### PR DESCRIPTION
This helped a lot when investigating the failed-create-over-existing-account bug. Hacky but works.