### PR TITLE
cmd/utils: enable snap dns discovery

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1691,6 +1691,11 @@ func SetDNSDiscoveryDefaults(cfg *eth.Config, genesis common.Hash) {
 	if url := params.KnownDNSNetwork(genesis, protocol); url != "" {
 		cfg.EthDiscoveryURLs = []string{url}
 	}
+	if cfg.SyncMode == downloader.SnapSync {
+		if url := params.KnownDNSNetwork(genesis, "snap"); url != "" {
+			cfg.SnapDiscoveryURLs = []string{url}
+		}
+	}
 }
 
 // RegisterEthService adds an Ethereum client to the stack.


### PR DESCRIPTION
This enables snap sync to find peers via DNS. 
Current status: 
```
TRACE[12-03|11:51:00.906] >> FINDNODE/v4                           id=6033ccab352b6a97 addr=52.64.102.159:30303   err=nil
TRACE[12-03|11:51:00.914] Updating DNS discovery root              tree=snap.mainnet.ethdisco.net err="lookup snap.mainnet.ethdisco.net on 10.139.1.1:53: no such host"
DEBUG[12-03|11:51:00.914] Error in DNS random node sync            tree=snap.mainnet.ethdisco.net err="lookup snap.mainnet.ethdisco.net on 10.139.1.1:53: no such host"
TRACE[12-03|11:51:00.921] Updating DNS discovery root              tree=snap.mainnet.ethdisco.net err="lookup snap.mainnet.ethdisco.net on 10.139.1.1:53: no such host"
DEBUG[12-03|11:51:00.921] Error in DNS random node sync            tree=snap.mainnet.ethdisco.net err="lookup snap.mainnet.ethdisco.net on 10.139.1.1:53: no such host"
TRACE[12-03|11:51:00.924] Updating DNS discovery root              tree=all.mainnet.ethdisco.net  err=nil
TRACE[12-03|11:51:00.929] Updating DNS discovery root              tree=snap.mainnet.ethdisco.net err="lookup snap.mainnet.ethdisco.net on 10.139.1.1:53: no such host"
DEBUG[12-03|11:51:00.929] Error in DNS random node sync            tree=snap.mainnet.ethdisco.net err="lookup snap.mainnet.ethdisco.net on 10.139.1.1:53: no such host"
TRACE[12-03|11:51:00.935] DNS discovery lookup                     name=FDXN3SN67NA5DKA4J2GOK7BVQI.all.mainnet.ethdisco.net err=nil

```
Requires 

1. https://github.com/ethereum/go-ethereum/pull/21950 to filter snap peers from the node list, then 
2. https://github.com/skylenet/discv4-crawl/pull/3 , so it actually publishes it, 

