### PR TITLE
eth/protocols/snap: make better use of delivered data

### DIFF
--- a/eth/protocols/snap/range_test.go
+++ b/eth/protocols/snap/range_test.go
@@ -17,7 +17,6 @@
 package snap
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -39,13 +38,13 @@ func TestHashRange(t *testing.T) {
 	next := common.Hash{}
 	last := r.End()
 	i := 0
-	fmt.Printf("Chunk %d, from %x to %x\n", i, next, last)
+	t.Logf("Chunk %d, from %x to %x\n", i, next, last)
 	chunks--
 	i++
 	for ; chunks > 0; chunks, i = chunks-1, i+1 {
 		r.Next()
 		next = r.Start()
 		last = r.End()
-		fmt.Printf("Chunk %d, from %x to %x\n", i, next, last)
+		t.Logf("Chunk %d, from %x to %x\n", i, next, last)
 	}
 }

--- a/eth/protocols/snap/range_test.go
+++ b/eth/protocols/snap/range_test.go
@@ -22,29 +22,122 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// TODO (@holiman): fix up this testcase properly
-func TestHashRange(t *testing.T) {
-	lastKey := common.HexToHash("0x1000000000000000000000000000000000000000000000000000000000000000")
-	nKeys := 10000
-	estimate, err := estimateRemainingSlots(nKeys, lastKey)
-	if err != nil {
-		t.Fatal(err)
+// Tests that given a starting hash and a density, the hash ranger can correctly
+// split up the remaining hash space into a fixed number of chunks.
+func TestHashRanges(t *testing.T) {
+	tests := []struct {
+		head   common.Hash
+		chunks uint64
+		starts []common.Hash
+		ends   []common.Hash
+	}{
+		// Simple test case to split the entire hash range into 4 chunks
+		{
+			head:   common.Hash{},
+			chunks: 4,
+			starts: []common.Hash{
+				{},
+				common.HexToHash("0x4000000000000000000000000000000000000000000000000000000000000000"),
+				common.HexToHash("0x8000000000000000000000000000000000000000000000000000000000000000"),
+				common.HexToHash("0xc000000000000000000000000000000000000000000000000000000000000000"),
+			},
+			ends: []common.Hash{
+				common.HexToHash("0x3fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+				common.HexToHash("0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+				common.HexToHash("0xbfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+				common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+			},
+		},
+		// Split a divisible part of the hash range up into 2 chunks
+		{
+			head:   common.HexToHash("0x2000000000000000000000000000000000000000000000000000000000000000"),
+			chunks: 2,
+			starts: []common.Hash{
+				common.Hash{},
+				common.HexToHash("0x9000000000000000000000000000000000000000000000000000000000000000"),
+			},
+			ends: []common.Hash{
+				common.HexToHash("0x8fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+				common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+			},
+		},
+		// Split the entire hash range into a non divisible 3 chunks
+		{
+			head:   common.Hash{},
+			chunks: 3,
+			starts: []common.Hash{
+				{},
+				common.HexToHash("0x5555555555555555555555555555555555555555555555555555555555555556"),
+				common.HexToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaac"),
+			},
+			ends: []common.Hash{
+				common.HexToHash("0x5555555555555555555555555555555555555555555555555555555555555555"),
+				common.HexToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab"),
+				common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+			},
+		},
+		// Split a part of hash range into a non divisible 3 chunks
+		{
+			head:   common.HexToHash("0x2000000000000000000000000000000000000000000000000000000000000000"),
+			chunks: 3,
+			starts: []common.Hash{
+				{},
+				common.HexToHash("0x6aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab"),
+				common.HexToHash("0xb555555555555555555555555555555555555555555555555555555555555556"),
+			},
+			ends: []common.Hash{
+				common.HexToHash("0x6aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+				common.HexToHash("0xb555555555555555555555555555555555555555555555555555555555555555"),
+				common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+			},
+		},
+		// Split a part of hash range into a non divisible 3 chunks, but with a
+		// meaningful space size for manual verification.
+		//   - The head being 0xff...f0, we have 14 hashes left in the space
+		//   - Chunking up 14 into 3 pieces is 4.(6), but we need the ceil of 5 to avoid a micro-last-chunk
+		//   - Since the range is not divisible, the last interval will be shrter, capped at 0xff...f
+		//   - The chunk ranges thus needs to be [..0, ..5], [..6, ..b], [..c, ..f]
+		{
+			head:   common.HexToHash("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0"),
+			chunks: 3,
+			starts: []common.Hash{
+				{},
+				common.HexToHash("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6"),
+				common.HexToHash("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc"),
+			},
+			ends: []common.Hash{
+				common.HexToHash("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff5"),
+				common.HexToHash("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffb"),
+				common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+			},
+		},
 	}
-	chunks := 1 + estimate/(2*10000)
-	t.Logf("Chunks: %d", chunks)
+	for i, tt := range tests {
+		r := newHashRange(tt.head, tt.chunks)
 
-	r := newHashRange(lastKey, chunks)
-	t.Logf("Step size: %x", r.step)
-	next := common.Hash{}
-	last := r.End()
-	i := 0
-	t.Logf("Chunk %d, from %x to %x\n", i, next, last)
-	chunks--
-	i++
-	for ; chunks > 0; chunks, i = chunks-1, i+1 {
-		r.Next()
-		next = r.Start()
-		last = r.End()
-		t.Logf("Chunk %d, from %x to %x\n", i, next, last)
+		var (
+			starts = []common.Hash{{}}
+			ends   = []common.Hash{r.End()}
+		)
+		for r.Next() {
+			starts = append(starts, r.Start())
+			ends = append(ends, r.End())
+		}
+		if len(starts) != len(tt.starts) {
+			t.Errorf("test %d: starts count mismatch: have %d, want %d", i, len(starts), len(tt.starts))
+		}
+		for j := 0; j < len(starts) && j < len(tt.starts); j++ {
+			if starts[j] != tt.starts[j] {
+				t.Errorf("test %d, start %d: hash mismatch: have %x, want %x", i, j, starts[j], tt.starts[j])
+			}
+		}
+		if len(ends) != len(tt.ends) {
+			t.Errorf("test %d: ends count mismatch: have %d, want %d", i, len(ends), len(tt.ends))
+		}
+		for j := 0; j < len(ends) && j < len(tt.ends); j++ {
+			if ends[j] != tt.ends[j] {
+				t.Errorf("test %d, end %d: hash mismatch: have %x, want %x", i, j, ends[j], tt.ends[j])
+			}
+		}
 	}
 }

--- a/eth/protocols/snap/range_test.go
+++ b/eth/protocols/snap/range_test.go
@@ -1,0 +1,51 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package snap
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// TODO (@holiman): fix up this testcase properly
+func TestHashRange(t *testing.T) {
+	lastKey := common.HexToHash("0x1000000000000000000000000000000000000000000000000000000000000000")
+	nKeys := 10000
+	estimate, err := estimateRemainingSlots(nKeys, lastKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chunks := 1 + estimate/(2*10000)
+	t.Logf("Chunks: %d", chunks)
+
+	r := newHashRange(lastKey, chunks)
+	t.Logf("Step size: %x", r.step)
+	next := common.Hash{}
+	last := r.End()
+	i := 0
+	fmt.Printf("Chunk %d, from %x to %x\n", i, next, last)
+	chunks--
+	i++
+	for ; chunks > 0; chunks, i = chunks-1, i+1 {
+		r.Next()
+		next = r.Start()
+		last = r.End()
+		fmt.Printf("Chunk %d, from %x to %x\n", i, next, last)
+	}
+}

--- a/eth/protocols/snap/rangeutils.go
+++ b/eth/protocols/snap/rangeutils.go
@@ -53,3 +53,10 @@ func (r *hashRange) Step() common.Hash {
 	r.current.Add(r.current, r.stepSize)
 	return common.Hash(r.current.Bytes32())
 }
+
+// incHash returns the next hash, in lexicographical order (a.k.a plus one)
+func incHash(h common.Hash) common.Hash {
+	a := uint256.NewInt().SetBytes32(h[:])
+	a.Add(a, uint256.NewInt().SetOne())
+	return common.Hash(a.Bytes32())
+}

--- a/eth/protocols/snap/rangeutils.go
+++ b/eth/protocols/snap/rangeutils.go
@@ -1,0 +1,55 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package snap
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+)
+
+// hashRange is a utility to handle ranges of hashes, Split up the
+// hash-space into sections, and 'walk' over the sections
+type hashRange struct {
+	current  *uint256.Int
+	stepSize *uint256.Int
+}
+
+// newHashRange creates a new hashRange, initiated at the start position,
+// and with the step set to fill the desired 'num' chunks
+func newHashRange(start common.Hash, num uint64) *hashRange {
+	i := uint256.NewInt()
+	i.SetBytes32(start[:])
+
+	// split the remaining range in 'num' sections
+	max := uint256.NewInt().SetAllOne()
+	remaining := max.Sub(max, i)
+	remaining.Div(remaining, uint256.NewInt().SetUint64(num))
+
+	return &hashRange{current: i, stepSize: remaining}
+}
+
+// Next increments the current position by 1 and returns the hash
+func (r *hashRange) Next() common.Hash {
+	r.current.Add(r.current, uint256.NewInt().SetOne())
+	return common.Hash(r.current.Bytes32())
+}
+
+// Step increments the current position by 'step' and returns the hash
+func (r *hashRange) Step() common.Hash {
+	r.current.Add(r.current, r.stepSize)
+	return common.Hash(r.current.Bytes32())
+}

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -1810,7 +1810,7 @@ func (s *Syncer) processStorageResponse(res *storageResponse) {
 					// Our first task is the one that was just filled by this response.
 					// It will be immediately filled further below
 					tasks = append(tasks, &storageTask{
-						Next:     next,
+						Next:     common.Hash{},
 						Last:     lastKey,
 						root:     acc.Root,
 						genBatch: batch,
@@ -1822,7 +1822,7 @@ func (s *Syncer) processStorageResponse(res *storageResponse) {
 					step.Sub(step, lastKey.Big())
 					step.Div(step, big.NewInt(int64(storageConcurrency)))
 					// The next request starts +1 from the last key we got
-					next = common.BigToHash(new(big.Int).Add(next.Big(), common.Big1))
+					next = common.BigToHash(new(big.Int).Add(lastKey.Big(), common.Big1))
 
 					for k := 0; k < storageConcurrency; k++ {
 						last := common.BigToHash(new(big.Int).Add(next.Big(), step))

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -1810,8 +1810,10 @@ func (s *Syncer) processStorageResponse(res *storageResponse) {
 					)
 					if estimate, err := estimateRemainingSlotCount(len(keys), lastKey); err == nil {
 						// If the number of slots remaining is low, decrease the parallelism.
-						// 8000 is roughly what fits into 500KB
-						if n := estimate / 8000; n < chunks {
+						// Somewhere on the order of 10K slots fits into a packet. We'd rather not chunk if
+						// each chunk is going to be only one single packet, so we use a factor of 2 to
+						// avoid chunking if we expect the remaining data to be filled with ~2 packets.
+						if n := estimate / (2 * 10000); n < chunks {
 							chunks = n
 						}
 						// Note, 'chunks' can become zero here, which means that the

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -1846,10 +1846,8 @@ func (s *Syncer) processStorageResponse(res *storageResponse) {
 							genTrie:  trie.NewStackTrie(batch),
 						})
 					}
-					// Make sure we don't overflow if the step is not a proper divisor
-					tasks[len(tasks)-1].Last = common.HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
 					for _, task := range tasks {
-						log.Info("Created storage sync task", "account", account, "root", acc.Root, "from", task.Next, "last", task.Last)
+						log.Debug("Created storage sync task", "account", account, "root", acc.Root, "from", task.Next, "last", task.Last)
 					}
 					res.mainTask.SubTasks[account] = tasks
 

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -1713,5 +1713,30 @@ func TestSlotEstimation(t *testing.T) {
 			t.Errorf("test %d: have %d want %d", i, have, want)
 		}
 	}
+}
 
+// TODO (@holiman): fix up this testcase properly
+func TestHashRange(t *testing.T) {
+	lastKey := common.HexToHash("0x1000000000000000000000000000000000000000000000000000000000000000")
+	nKeys := 10000
+	estimate, err := estimateRemainingSlotCount(nKeys, lastKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chunks := 1 + estimate/(2*10000)
+	t.Logf("Chunks: %d", chunks)
+
+	r := newHashRange(lastKey, chunks)
+	t.Logf("Step size: %x", r.stepSize)
+	next := common.Hash{}
+	last := r.Step()
+	i := 0
+	fmt.Printf("Chunk %d, from %x to %x\n", i, next, last)
+	chunks--
+	i++
+	for ; chunks > 0; chunks, i = chunks-1, i+1 {
+		next = r.Next()
+		last = r.Step()
+		fmt.Printf("Chunk %d, from %x to %x\n", i, next, last)
+	}
 }

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -1664,3 +1664,54 @@ func TestSyncAccountPerformance(t *testing.T) {
 		t.Errorf("trie node heal requests wrong, want %d, have %d", want, have)
 	}
 }
+
+func TestSlotEstimation(t *testing.T) {
+	for i, tc := range []struct {
+		last  common.Hash
+		count int
+		want  uint64
+	}{
+		{
+			// Half the space
+			common.HexToHash("0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+			100,
+			100,
+		},
+		{
+			// 1 / 16th
+			common.HexToHash("0x0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+			100,
+			1500,
+		},
+		{
+			// Bit more than 1 / 16th
+			common.HexToHash("0x1000000000000000000000000000000000000000000000000000000000000000"),
+			100,
+			1499,
+		},
+		{
+			// Almost everything
+			common.HexToHash("0xF000000000000000000000000000000000000000000000000000000000000000"),
+			100,
+			6,
+		},
+		{
+			// Almost nothing -- should lead to error
+			common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+			1,
+			0,
+		},
+		{
+			// Nothing -- should lead to error
+			common.Hash{},
+			100,
+			0,
+		},
+	} {
+		have, _ := estimateRemainingSlotCount(tc.count, tc.last)
+		if want := tc.want; have != want {
+			t.Errorf("test %d: have %d want %d", i, have, want)
+		}
+	}
+
+}

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -1708,35 +1708,9 @@ func TestSlotEstimation(t *testing.T) {
 			0,
 		},
 	} {
-		have, _ := estimateRemainingSlotCount(tc.count, tc.last)
+		have, _ := estimateRemainingSlots(tc.count, tc.last)
 		if want := tc.want; have != want {
 			t.Errorf("test %d: have %d want %d", i, have, want)
 		}
-	}
-}
-
-// TODO (@holiman): fix up this testcase properly
-func TestHashRange(t *testing.T) {
-	lastKey := common.HexToHash("0x1000000000000000000000000000000000000000000000000000000000000000")
-	nKeys := 10000
-	estimate, err := estimateRemainingSlotCount(nKeys, lastKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-	chunks := 1 + estimate/(2*10000)
-	t.Logf("Chunks: %d", chunks)
-
-	r := newHashRange(lastKey, chunks)
-	t.Logf("Step size: %x", r.stepSize)
-	next := common.Hash{}
-	last := r.Step()
-	i := 0
-	fmt.Printf("Chunk %d, from %x to %x\n", i, next, last)
-	chunks--
-	i++
-	for ; chunks > 0; chunks, i = chunks-1, i+1 {
-		next = r.Next()
-		last = r.Step()
-		fmt.Printf("Chunk %d, from %x to %x\n", i, next, last)
 	}
 }


### PR DESCRIPTION
This is a bit of a rough implementation, I haven't verifiied if it works totally correct. 
Currently, when we retrieve a contract storage which is too large to fit in a single response, but otherwise "pretty small", then we discard data. 

The received data might be `[0x0..,,,0x1...., 0x4..]`. We divide the 'space' into 16 chunks, and immediately fill the first chunk with the data. Then we trim the edge, and thus keep `[0x0..,]'` but throw away `[0x1...., 0x4..]`, which will instead be fetched separately in later chunks. 

This PR also adds the (so far not used) method `estimateRemainingSlots`, which can be used to further tune the level of parallelism we choose. 